### PR TITLE
v1.5.1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-### Pending
+# Pending
 * Added config group headers
 * Readme clarifications
 * Logging when objects are filtered out by Stealthy
@@ -9,38 +9,38 @@
 * Exp: Accounts for darkvision lighting adjustments
 * Exp: Adjust passive perception based on target token lighting
 
-### Version 1.4.0
+# Version 1.4.0
 * Option to disable token effect on Hidden
 * Ensure Spot effect isn't disabled after rolling Perception
 * Use MIXED libwrappers
 
-### Version 1.3.1
+# Version 1.3.1
 * Fix merge error
 
-### Version 1.3.0
+# Version 1.3.0
 * Allow selection for source of Hidden effect
 * Support CUB as possible Hidden source
 * Handle disabled Hidden/Spot effects
 * Tighten up logging function
 
-### Version 1.2.4
+# Version 1.2.4
 * Added dubious feature GIFs to readme
 
-### Version 1.2.3
+# Version 1.2.3
 * Added Logging method
 
-### Version 1.2.2
+# Version 1.2.2
 * Fix stealthy.hidden and stealthy.spot flag access
 
-### Version 1.2.0
+# Version 1.2.0
 * Check for Umbral Sight feature rather than Gloom Stalker subclass
 * Localization support
 * Dnd5e specific code guarded by game.system.id checks
 * Github workflows support
 * Use ATL 50% token alpha as fallback if no TokenMagicFX present
 
-### Version 1.1.0
+# Version 1.1.0
 * DFreds Convenient Effects is now optional
 
-### Version 1.0.0
+# Version 1.0.0
 * Initial implementation

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,9 +1,10 @@
 ### Pending
 * Added config group headers
-* Adding experimental group config header
 * Readme clarifications
 * Logging when objects are filtered out by Stealthy
-* Experimental Token lighting option
+* Better organization for the isHidden test
+* Adding experimental group config header
+* Exp: Token lighting option
 * Exp: Check for dim/dark effects on target token
 * Exp: Accounts for darkvision lighting adjustments
 * Exp: Adjust passive perception based on target token lighting

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,10 @@
 ### Pending
 * Added config group headers
+* Adding experimental group config header
+* Experimental Token lighting option
+* Exp: Check for dim/dark effects on target token
+* Exp: Accounts for darkvision lighting adjustments
+* Exp: Adjust passive perception based on target token lighting
 
 ### Version 1.4.0
 * Option to disable token effect on Hidden

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,7 @@
 # Version 1.5.0
-* Added token control toggle to dynamically disable Spot condition generation
-* Added config group headers
-* Readme clarifications
-* Logging when objects are filtered out by Stealthy
+* Added socketlib as a required module
+* Added token control for GM to toggle Spot effect generation across all clients
+* Added Logging when objects are filtered out by Stealthy
 * Better code organization
 * Grouped related settings in the settings dialog
 * Experimental: option for perception checks to be affected by Dim or Dark status conditions on the token. Only affect passive perception currently.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,13 +1,11 @@
-# Pending
+# Version 1.5.0
+* Added token control toggle to dynamically disable Spot condition generation
 * Added config group headers
 * Readme clarifications
 * Logging when objects are filtered out by Stealthy
-* Better organization for the isHidden test
-* Adding experimental group config header
-* Exp: Token lighting option
-* Exp: Check for dim/dark effects on target token
-* Exp: Accounts for darkvision lighting adjustments
-* Exp: Adjust passive perception based on target token lighting
+* Better code organization
+* Grouped related settings in the settings dialog
+* Experimental: option for perception checks to be affected by Dim or Dark status conditions on the token. Only affect passive perception currently.
 
 # Version 1.4.0
 * Option to disable token effect on Hidden

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+### Pending
+* Added config group headers
+
 ### Version 1.4.0
 * Option to disable token effect on Hidden
 * Ensure Spot effect isn't disabled after rolling Perception

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # Version 1.5.0
 * Added socketlib as a required module
 * Added token control for GM to toggle Spot effect generation across all clients
-* Added Logging when objects are filtered out by Stealthy
+* Added optional Logging when objects are filtered out by Stealthy
 * Better code organization
 * Grouped related settings in the settings dialog
 * Experimental: option for perception checks to be affected by Dim or Dark status conditions on the token. Only affect passive perception currently.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# Version 1.5.1
+* Fixed incorrect name use when toggling Spot
+
 # Version 1.5.0
 * Added socketlib as a required module
 * Added token control for GM to toggle Spot effect generation across all clients

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
 ### Pending
 * Added config group headers
 * Adding experimental group config header
+* Readme clarifications
+* Logging when objects are filtered out by Stealthy
 * Experimental Token lighting option
 * Exp: Check for dim/dark effects on target token
 * Exp: Accounts for darkvision lighting adjustments

--- a/README.md
+++ b/README.md
@@ -22,11 +22,12 @@ Rolling a Stealth skill check will apply the Hidden condition to the actor and r
 ![stealth-roll](https://user-images.githubusercontent.com/16523503/209989026-e0d2dad2-8dc1-459c-8824-a2332ce8a9cd.gif)
 
 ### **Rolling Perception checks applies the Spot condition**
-Rolling a Perception check will add a one turn/six second duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor). The duration isn't from RAW, but is an approximation I've chosen that seems to work well in my games. A toggle named 'Spot condition toggle' is available under token controls to suspend adding of the Spot condition as the GM sees fit. Toggling it off will also clear out all Spot effects.
+Rolling a Perception check will add a one turn/six second duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor). The duration isn't from RAW, but is an approximation I've chosen that seems to work well in my games. A toggle named 'Toggle Active Spot' is available under token controls to suspend adding of the Spot condition as the GM sees fit. Toggling it off will also clear out all Spot effects.
 
 *The stored Perception value uses passive Perception as a floor to the Active roll result.*
 
 ![perception](https://user-images.githubusercontent.com/16523503/209989470-aac2bdb4-fee4-44c0-a6b7-916e69353081.gif)
+![control](https://user-images.githubusercontent.com/16523503/210176825-3fcb3183-81db-4f64-836a-81f29199b580.png)
 
 ### **GM Stealth Override**
 Once the Hidden condition is applied, GMs will see a token button with an input box on the bottom right which will shows the rolled Stealth result, or show the passive Stealth value if the Hidden condition was added directly without rolling. Changing the value in this input box will alter the stored Stealth result for any future visibility tests.
@@ -40,6 +41,8 @@ Characters with Umbral Sight will no longer be visible to the Darkvision mode, b
 
 ### **Invisible characters can hide from See Invisibility**
 An invisible actor that also has the 'Hidden' condition will check Perception vs Stealth before showing up in the 'See Invisibility' vision mode.
+
+![invisible](https://user-images.githubusercontent.com/16523503/210176827-03fda57a-6d09-4144-8253-b8b7cd9155ac.gif)
 
 ### **Friendly tokens can still be viewed**
 The GM has the option for allowing Hidden tokens to be seen by other tokens of the same disposition.

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Rolling a Stealth skill check will apply the Hidden condition to the actor and r
 ![stealth-roll](https://user-images.githubusercontent.com/16523503/209989026-e0d2dad2-8dc1-459c-8824-a2332ce8a9cd.gif)
 
 ### **Rolling Perception checks applies the Spot condition**
-Rolling a Perception check will add a one turn/six second duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor). The duration isn't from RAW, but is an approximation I've chosen that seems to work well in my games. A toggle entitled 'Perception creates Spot effect' is available under token controls to suspend adding of the Spot condition as the GM sees fit.
+Rolling a Perception check will add a one turn/six second duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor). The duration isn't from RAW, but is an approximation I've chosen that seems to work well in my games. A toggle named 'Spot condition toggle' is available under token controls to suspend adding of the Spot condition as the GM sees fit. Toggling it off will also clear out all Spot effects.
 
 *The stored Perception value uses passive Perception as a floor to the Active roll result.*
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ Rolling a Stealth skill check will apply the Hidden condition to the actor and r
 ![stealth-roll](https://user-images.githubusercontent.com/16523503/209989026-e0d2dad2-8dc1-459c-8824-a2332ce8a9cd.gif)
 
 ### **Rolling Perception checks applies the Spot condition**
-Rolling a Perception check will add a one turn/six second duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor). The duration isn't from RAW, but is an approximation I've chosen that seems to work well in my games.
+Rolling a Perception check will add a one turn/six second duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor). The duration isn't from RAW, but is an approximation I've chosen that seems to work well in my games. A toggle entitled 'Perception creates Spot effect' is available under token controls to suspend adding of the Spot condition as the GM sees fit.
 
-The stored Perception value uses passive Perception as a floor to the Active roll result.
+*The stored Perception value uses passive Perception as a floor to the Active roll result.*
 
 ![perception](https://user-images.githubusercontent.com/16523503/209989470-aac2bdb4-fee4-44c0-a6b7-916e69353081.gif)
 

--- a/README.md
+++ b/README.md
@@ -2,18 +2,22 @@
 [![Latest Version](https://img.shields.io/github/v/release/eligarf/stealthy?display_name=tag&sort=semver&label=Latest%20Version)](https://github.com/eligarf/stealthy/releases/latest)
 ![Foundry Version](https://img.shields.io/endpoint?url=https://foundryshields.com/version?url=https%3A%2F%2Fraw.githubusercontent.com%2Feligarf%2Fstealthy%2Fdev%2Fmodule.json)
 
+![Latest Downloads](https://img.shields.io/github/downloads/eligarf/stealthy/latest/total?color=blue&label=latest%20downloads)
+![Total Downloads](https://img.shields.io/github/downloads/eligarf/stealthy/total?color=blue&label=total%20downloads)
 # Stealthy
 
 A module for [FoundryVTT](https://foundryvtt.com) that adds perception vs stealth testing to Foundry's visibility tests.
 
 ## Purpose
 
-During visibility tests, Stealthy filters out any objects with the 'Hidden' condition if the viewing Perception value fails to beat the object's Stealth value.
+During visibility tests, Stealthy filters out any objects with the Hidden condition if the viewing Perception value fails to beat the object's Stealth value.
 
 ## Features
 
 ### **Rolling Stealth checks applies the Hidden condition**
-Rolling a Stealth skill check will apply the 'hidden' condition to the actor and record the result of the check in that condition for later comparisons, replacing the stored result if the Hidden condition is already present. Stealthy's default Hidden effect can be overriden by adding a custom Hidden effect in either Convenient Effects or CUB.
+Rolling a Stealth skill check will apply the Hidden condition to the actor and record the result of the check in that condition for later comparisons, replacing the stored result if the Hidden condition is already present. Stealthy's default Hidden effect can be overriden by adding a custom Hidden effect in either Convenient Effects or CUB.
+
+**Stealthy does not attempt to manage when to remove the Hidden or Spot effects. Modules like the most excellent [Midi-QOL](https://foundryvtt.com/packages/midi-qol) can handle those duties.**
 
 ![stealth-roll](https://user-images.githubusercontent.com/16523503/209989026-e0d2dad2-8dc1-459c-8824-a2332ce8a9cd.gif)
 
@@ -41,7 +45,7 @@ An invisible actor that also has the 'Hidden' condition will check Perception vs
 The GM has the option for allowing Hidden tokens to be seen by other tokens of the same disposition.
 
 ## Stealth vs Perception Ties
-D&D 5E treats skill contest ties as preserving the status quo, so I assume that ties are won by passive Perception and lost by active Perception. Its not perfect, but seems to do a decent job.
+D&D 5E treats skill contest ties as preserving the status quo, so use of passive value for either skill makes a claim of owning the status quo and thus winning ties. If Perception and Stealth are both passive, I assume Stealth takes the active role of wanting to change the status quo from visible to hidden. An active Perception check is only necessary if the passive Perception was beaten by Stealth, so in this case Hidden is now the status quo condition and Stealth wins ties with the active result. More simply, **ties are won by passive Perception and lost by active Perception.**
 
 ## Experimental
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,14 @@ During visibility tests, Stealthy filters out any objects with the 'Hidden' cond
 ## Features
 
 ### **Rolling Stealth checks applies the Hidden condition**
-Rolling a Stealth skill check will apply the 'hidden' condition to the actor and record the result of the check in that condition for later comparisons, replacing the stored result if the Hidden condition is already present. If using DFreds Convenient Effects, a custom Hidden effect will be created therein if no custom effect named Hidden can be found. This effect can be customized as you see fit, but it must remain named 'Hidden'.
+Rolling a Stealth skill check will apply the 'hidden' condition to the actor and record the result of the check in that condition for later comparisons, replacing the stored result if the Hidden condition is already present. Stealthy's default Hidden effect can be overriden by adding a custom Hidden effect in either Convenient Effects or CUB.
 
 ![stealth-roll](https://user-images.githubusercontent.com/16523503/209989026-e0d2dad2-8dc1-459c-8824-a2332ce8a9cd.gif)
 
 ### **Rolling Perception checks applies the Spot condition**
-Rolling a Perception check will add a 'Spot' condition to the actor which records the result of that perception check. The passive value for Perception is used if this condition isn't present on the actor. *The stored Perception result uses the passive value as a floor*
+Rolling a Perception check will add a 'Spot' condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor).
+
+The stored Perception value uses passive Perception as a floor to the Active roll result.
 
 ![perception](https://user-images.githubusercontent.com/16523503/209989470-aac2bdb4-fee4-44c0-a6b7-916e69353081.gif)
 
@@ -37,6 +39,9 @@ An invisible actor that also has the 'Hidden' condition will check Perception vs
 
 ### **Friendly tokens can still be viewed**
 The GM has the option for allowing Hidden tokens to be seen by other tokens of the same disposition.
+
+## Stealth vs Perception Ties
+D&D 5E treats skill contest ties as preserving the status quo, so I assume that ties are won by passive Perception and lost by active Perception. Its not perfect, but seems to do a decent job.
 
 ## Required modules
 * [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper)

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ This takes Darkvision into account for light conditions ( light level bump ) bef
 
 ## Required modules
 * [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper)
+* [socketlib](https://github.com/manuelVo/foundryvtt-socketlib)
 ## Optional modules
 * [DFreds Convenient Effects](https://foundryvtt.com/packages/dfreds-convenient-effects)
 * [Combat Utility Belt](https://foundryvtt.com/packages/combat-utility-belt)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![License](https://img.shields.io/github/license/eligarf/stealthy?label=License)](LICENSE)
 [![Latest Version](https://img.shields.io/github/v/release/eligarf/stealthy?display_name=tag&sort=semver&label=Latest%20Version)](https://github.com/eligarf/stealthy/releases/latest)
-![Foundry Version](https://img.shields.io/endpoint?url=https://foundryshields.com/version?url=https%3A%2F%2Fraw.githubusercontent.com%2Feligarf%2Fstealthy%2Fmain%2Fmodule.json)
+![Foundry Version](https://img.shields.io/endpoint?url=https://foundryshields.com/version?url=https%3A%2F%2Fraw.githubusercontent.com%2Feligarf%2Fstealthy%2Fdev%2Fmodule.json)
 
 # Stealthy
 

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@ During visibility tests, Stealthy filters out any objects with the Hidden condit
 ### **Rolling Stealth checks applies the Hidden condition**
 Rolling a Stealth skill check will apply the Hidden condition to the actor and record the result of the check in that condition for later comparisons, replacing the stored result if the Hidden condition is already present. Stealthy's default Hidden effect can be overriden by adding a custom Hidden effect in either Convenient Effects or CUB.
 
-**Stealthy does not attempt to manage when to remove the Hidden or Spot effects. Modules like the most excellent [Midi-QOL](https://foundryvtt.com/packages/midi-qol) can handle those duties.**
+***Stealthy will not automatically remove the Hidden condition - see the [Skulker](https://www.dndbeyond.com/feats/skulker) feat for why deleting Hidden gets complicated without heavier automation support provided by modules like the excellent [Midi-QOL](https://foundryvtt.com/packages/midi-qol) which handles this for my games. I suggest [DFreds Effects Panel](https://foundryvtt.com/packages/dfreds-effects-panel) as an easier way to manually remove it, especially for low automation level games.***
 
 ![stealth-roll](https://user-images.githubusercontent.com/16523503/209989026-e0d2dad2-8dc1-459c-8824-a2332ce8a9cd.gif)
 
 ### **Rolling Perception checks applies the Spot condition**
-Rolling a Perception check will add a 'Spot' condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor).
+Rolling a Perception check will add a one round duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor).
 
 The stored Perception value uses passive Perception as a floor to the Active roll result.
 
 ![perception](https://user-images.githubusercontent.com/16523503/209989470-aac2bdb4-fee4-44c0-a6b7-916e69353081.gif)
 
 ### **GM Stealth Override**
-Once the 'Hidden' condition is applied, GMs will see a token button with an input box on the bottom right which will shows the rolled Stealth result, or show the passive Stealth value if the Hidden condition was added directly without rolling. Changing the value in this input box will alter the stored Stealth result for any future visibility tests.
+Once the Hidden condition is applied, GMs will see a token button with an input box on the bottom right which will shows the rolled Stealth result, or show the passive Stealth value if the Hidden condition was added directly without rolling. Changing the value in this input box will alter the stored Stealth result for any future visibility tests.
 
 ![stealth-override](https://user-images.githubusercontent.com/16523503/209896031-675ab0e3-93e6-4d9c-8eeb-c11abe39fdab.gif)
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ The GM has the option for allowing Hidden tokens to be seen by other tokens of t
 ## Stealth vs Perception Ties
 D&D 5E treats skill contest ties as preserving the status quo, so I assume that ties are won by passive Perception and lost by active Perception. Its not perfect, but seems to do a decent job.
 
+## Experimental
+
+### Check token lighting conditions
+This option triggers a check for the following effects on the target token:
+    Dark, Dim
+IF the target token has these effects, then the passive perception check will be adjusted accordingly.
+This takes Darkvision into account for light conditions ( light level bump ) before determining passive perception adjustment.
+
 ## Required modules
 * [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper)
 ## Optional modules

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ During visibility tests, Stealthy filters out any objects with the Hidden condit
 ### **Rolling Stealth checks applies the Hidden condition**
 Rolling a Stealth skill check will apply the Hidden condition to the actor and record the result of the check in that condition for later comparisons, replacing the stored result if the Hidden condition is already present. Stealthy's default Hidden effect can be overriden by adding a custom Hidden effect in either Convenient Effects or CUB.
 
-***Stealthy will not automatically remove the Hidden condition - see the [Skulker](https://www.dndbeyond.com/feats/skulker) feat for why deleting Hidden gets complicated without heavier automation support provided by modules like the excellent [Midi-QOL](https://foundryvtt.com/packages/midi-qol) which handles this for my games. I suggest [DFreds Effects Panel](https://foundryvtt.com/packages/dfreds-effects-panel) as an easier way to manually remove it, especially for low automation level games.***
+***See [Handling Hidden removal](#handling-hidden-removal)***
 
 ![stealth-roll](https://user-images.githubusercontent.com/16523503/209989026-e0d2dad2-8dc1-459c-8824-a2332ce8a9cd.gif)
 
 ### **Rolling Perception checks applies the Spot condition**
-Rolling a Perception check will add a one round duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor).
+Rolling a Perception check will add a one turn/six second duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor). The duration isn't from RAW, but is an approximation I've chosen that seems to work well in my games.
 
 The stored Perception value uses passive Perception as a floor to the Active roll result.
 
@@ -44,6 +44,8 @@ An invisible actor that also has the 'Hidden' condition will check Perception vs
 ### **Friendly tokens can still be viewed**
 The GM has the option for allowing Hidden tokens to be seen by other tokens of the same disposition.
 
+## Handling Hidden removal
+Stealthy will not automatically remove the Hidden condition - the [Skulker](https://www.dndbeyond.com/feats/skulker) feat demonstrates why removing Hidden gets complicated without heavier automation support provided by modules like the excellent [Midi-QOL](https://foundryvtt.com/packages/midi-qol) which handles this for my games. I suggest [DFreds Effects Panel](https://foundryvtt.com/packages/dfreds-effects-panel) as an easier way to manually remove it, especially for low automation level games. 
 ## Stealth vs Perception Ties
 D&D 5E treats skill contest ties as preserving the status quo, so use of passive value for either skill makes a claim of owning the status quo and thus winning ties. If Perception and Stealth are both passive, I assume Stealth takes the active role of wanting to change the status quo from visible to hidden. An active Perception check is only necessary if the passive Perception was beaten by Stealth, so in this case Hidden is now the status quo condition and Stealth wins ties with the active result. More simply, **ties are won by passive Perception and lost by active Perception.**
 
@@ -51,7 +53,9 @@ D&D 5E treats skill contest ties as preserving the status quo, so use of passive
 
 ### Check token lighting conditions
 This option triggers a check for the following effects on the target token:
-    Dark, Dim
+- Dark
+- Dim
+
 IF the target token has these effects, then the passive perception check will be adjusted accordingly.
 This takes Darkvision into account for light conditions ( light level bump ) before determining passive perception adjustment.
 

--- a/lang/en.json
+++ b/lang/en.json
@@ -20,5 +20,8 @@
   "stealthy-logLevel-debuglevel-choice": "Debug level",
   "stealthy-logLevel-loglevel-choice": "Log level",
   "stealthy-config-general": "General Options",
-  "stealthy-config-debug": "Debug Options"
+  "stealthy-config-debug": "Debug Options",
+  "stealthy-config-experimental": "Experimental",
+  "stealthy-tokenLighting-name": "Check token lighting conditions",
+  "stealthy-tokenLighting-hint": "Check for token effects that indicate lighting condition of the token"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -4,6 +4,7 @@
   "stealthy-hidden-error": "Can't find effect named Hidden",
   "stealthy-spot": "Spot",
   "stealthy-spot-description": "Active Perception check result",
+  "stealthy-spotting-toggle": "Perception creates Spot effect",
   "stealthy-inputBox-title": "Current Stealth",
   "stealthy-ignoreFriendlyStealth-name": "Ignore friendly stealth",
   "stealthy-ignoreFriendlyStealth-hint": "Perception vs Stealth tests will be ignored for tokens of the same disposition",

--- a/lang/en.json
+++ b/lang/en.json
@@ -4,7 +4,7 @@
   "stealthy-hidden-error": "Can't find effect named Hidden",
   "stealthy-spot": "Spot",
   "stealthy-spot-description": "Active Perception check result",
-  "stealthy-spotting-toggle": "Perception creates Spot effect",
+  "stealthy-spotting-toggle": "Spot condition toggle",
   "stealthy-inputBox-title": "Current Stealth",
   "stealthy-ignoreFriendlyStealth-name": "Ignore friendly stealth",
   "stealthy-ignoreFriendlyStealth-hint": "Perception vs Stealth tests will be ignored for tokens of the same disposition",

--- a/lang/en.json
+++ b/lang/en.json
@@ -23,5 +23,5 @@
   "stealthy-config-debug": "Debug Options",
   "stealthy-config-experimental": "Experimental",
   "stealthy-tokenLighting-name": "Check token lighting conditions",
-  "stealthy-tokenLighting-hint": "Check for token effects that indicate lighting condition of the token"
+  "stealthy-tokenLighting-hint": "Check for token effects that indicate lighting condition of the token. WARNING - only currently handles passive perception"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -18,5 +18,7 @@
   "stealthy-logLevel-name": "Logging Level",
   "stealthy-logLevel-none-choice": "No logging",
   "stealthy-logLevel-debuglevel-choice": "Debug level",
-  "stealthy-logLevel-loglevel-choice": "Log level"
+  "stealthy-logLevel-loglevel-choice": "Log level",
+  "stealthy-config-general": "General Options",
+  "stealthy-config-debug": "Debug Options"
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -4,7 +4,7 @@
   "stealthy-hidden-error": "Can't find effect named Hidden",
   "stealthy-spot": "Spot",
   "stealthy-spot-description": "Active Perception check result",
-  "stealthy-spotting-toggle": "Spot condition toggle",
+  "stealthy-spotting-toggle": "Toggle Active Spot",
   "stealthy-inputBox-title": "Current Stealth",
   "stealthy-ignoreFriendlyStealth-name": "Ignore friendly stealth",
   "stealthy-ignoreFriendlyStealth-hint": "Perception vs Stealth tests will be ignored for tokens of the same disposition",

--- a/module.json
+++ b/module.json
@@ -4,17 +4,18 @@
   "description": "Adds perception vs stealth checks to vision tests for tokens with the Hidden condition",
   "authors": [
     {
-      "name": "Eligarf"
+      "name": "Eligarf",
+      "flags": {}
     },
     {
-      "name": "Frstrm"
+      "name": "Frstrm",
+      "flags": {}
     }
   ],
-  "version": "1.4.0",
+  "version": "1.5.0",
   "compatibility": {
     "minimum": "10.291",
-    "verified": "10.291",
-    "maximum": "10"
+    "verified": "10.291"
   },
   "minimumCoreVersion": 10,
   "system": [
@@ -24,22 +25,24 @@
     "requires": [
       {
         "id": "lib-wrapper",
-        "type": "module"
+        "type": "module",
+        "compatibility": {}
       }
     ]
   },
   "esmodules": [
-    "./scripts/config.js",
-    "./scripts/stealthy.js"
+    "scripts/config.js",
+    "scripts/stealthy.js"
   ],
   "languages": [
     {
       "lang": "en",
       "name": "English",
-      "path": "./lang/en.json"
+      "path": "lang/en.json",
+      "flags": {}
     }
   ],
-  "download": "https://github.com/Eligarf/stealthy/releases/download/v1.4.0/stealthy.zip",
+  "download": "https://github.com/Eligarf/stealthy/releases/download/v1.5.0/stealthy.zip",
   "changelog": "https://raw.githubusercontent.com/eligarf/stealthy/release/ChangeLog.md",
   "url": "https://github.com/Eligarf/stealthy",
   "manifest": "https://github.com/Eligarf/stealthy/releases/latest/download/module.json",

--- a/module.json
+++ b/module.json
@@ -40,7 +40,7 @@
     }
   ],
   "download": "https://github.com/Eligarf/stealthy/releases/download/v1.4.0/stealthy.zip",
-  "changelog": "https://raw.githubusercontent.com/eligarf/stealthy/main/ChangeLog.md",
+  "changelog": "https://raw.githubusercontent.com/eligarf/stealthy/release/ChangeLog.md",
   "url": "https://github.com/Eligarf/stealthy",
   "manifest": "https://github.com/Eligarf/stealthy/releases/latest/download/module.json",
   "bugs": "https://github.com/Eligarf/stealthy/issues",

--- a/module.json
+++ b/module.json
@@ -26,11 +26,13 @@
       {
         "id": "lib-wrapper",
         "type": "module",
+        "manifest": "https://github.com/ruipin/fvtt-lib-wrapper",
         "compatibility": {}
       },
       {
         "id": "socketlib",
         "type": "module",
+        "manifest": "https://raw.githubusercontent.com/manuelVo/foundryvtt-socketlib/master/module.json",
         "compatibility": {}
       }
     ]
@@ -47,6 +49,7 @@
       "flags": {}
     }
   ],
+  "socket": true,
   "download": "https://github.com/Eligarf/stealthy/releases/download/v1.5.0/stealthy.zip",
   "changelog": "https://raw.githubusercontent.com/eligarf/stealthy/release/ChangeLog.md",
   "url": "https://github.com/Eligarf/stealthy",

--- a/module.json
+++ b/module.json
@@ -27,6 +27,11 @@
         "id": "lib-wrapper",
         "type": "module",
         "compatibility": {}
+      },
+      {
+        "id": "socketlib",
+        "type": "module",
+        "compatibility": {}
       }
     ]
   },

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -68,5 +68,5 @@ Hooks.once('ready', () => {
     default: false,
   });
 
-  
+
 });

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -58,5 +58,15 @@ Hooks.once('ready', () => {
     },
     default: 'none'
   });
+
+  game.settings.register('stealthy', 'tokenLighting', {
+    name: game.i18n.localize("stealthy-tokenLighting-name"),
+    hint: game.i18n.localize("stealthy-tokenLighting-hint"),
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+
   
 });

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -1,8 +1,9 @@
+import { Stealthy } from "./stealthy.js";
+
 Hooks.once('ready', () => {
 
   const module = game.modules.get('stealthy');
   const moduleVersion = module.version;
-  console.log(`stealthy | Initializing ${moduleVersion}`);
 
   game.settings.register('stealthy', 'ignoreFriendlyStealth', {
     name: game.i18n.localize("stealthy-ignoreFriendlyStealth-name"),
@@ -68,5 +69,5 @@ Hooks.once('ready', () => {
     default: false,
   });
 
-
+  Stealthy.log(`Initialized ${moduleVersion}`);
 });

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -23,7 +23,36 @@ export class Stealthy {
     }
   }
 
-  static calcPerception5e(visionSource, source, target) {
+  // check target Token Lighting conditions via effects usage
+  // look for effects that indicate Dim or Dark condition on the token
+  static tokenLighting5e(spot, perception, visionSource, source, target) {
+    let lightLevel = 2;
+    let debugData = { perception };
+
+    if (target?.effects.find(e => e.label === 'Dark' && !e.disabled)) { lightLevel = 0; }
+    if (target?.effects.find(e => e.label === 'Dim' && !e.disabled)) { lightLevel = 1; }
+    debugData.lightLevel = Stealthy.lightNumTable[lightLevel];
+
+    // check if Darkvision is in use, bump light level accordingly
+    if (visionSource.visionMode?.id === 'darkvision') {
+      lightLevel = lightLevel + 1;
+      debugData.darklightLevel = Stealthy.lightNumTable[lightLevel];
+    }
+
+    // adjust passive perception depending on light conditions of target token
+    // don't adjust for active perception checks via 'spot' flag usage
+    if (lightLevel < 2 && !spot?.flags.stealthy?.spot) {
+      perception = perception - 5;
+      debugData.disadvantagedPassive = perception;
+    };
+
+    Stealthy.log("tokenLighting5e", debugData);
+    return perception;
+  }
+
+  static isHidden5e(visionSource, hidden, target, config) {
+    const source = visionSource.object?.actor;
+    const stealth = hidden.flags.stealthy?.hidden ?? target.system.skills.ste.passive;
     const spot = source?.effects.find(e => e.label === game.i18n.localize("stealthy-spot") && !e.disabled);
 
     // active perception loses ties, passive perception wins ties to simulate the
@@ -31,38 +60,10 @@ export class Stealthy {
     // perception means that stealth is being the active skill.
     let perception = spot?.flags.stealthy?.spot ?? (source.system.skills.prc.passive + 1);
 
-    // check target Token Lighting conditions via effects usage
-    // look for effects that indicate Dim or Dark condition on the token
     if (game.settings.get('stealthy', 'tokenLighting')) {
-      let lightLevel = 2;
-      let debugData = { perception };
-
-      if (target?.effects.find(e => e.label === 'Dark' && !e.disabled)) { lightLevel = 0; }
-      if (target?.effects.find(e => e.label === 'Dim' && !e.disabled)) { lightLevel = 1; }
-      debugData.lightLevel = Stealthy.lightNumTable[lightLevel];
-
-      // check if Darkvision is in use, bump light level accordingly
-      if (visionSource.visionMode?.id === 'darkvision') {
-        lightLevel = lightLevel + 1;
-        debugData.darklightLevel = Stealthy.lightNumTable[lightLevel];
-      }
-
-      // adjust passive perception depending on light conditions of target token
-      // don't adjust for active perception checks via 'spot' flag usage
-      if (lightLevel < 2 && !spot?.flags.stealthy?.spot) {
-        perception = perception - 5;
-        debugData.disadvantagedPassive = perception;
-      };
-
-      Stealthy.log("tokenLighting", debugData);
+      perception = Stealthy.tokenLighting5e(spot, perception, visionSource, source, target);
     }
-    return perception;
-  }
 
-  static isHidden5e(visionSource, hidden, target, config) {
-    const source = visionSource.object?.actor;
-    const stealth = hidden.flags.stealthy?.hidden ?? target.system.skills.ste.passive;
-    const perception = Stealthy.calcPerception5e(visionSource, source, target);
     if (perception <= stealth) {
       Stealthy.log(`${visionSource.object.name}'s ${perception} can't see ${config.object.name}'s ${stealth}`);
       return true;
@@ -70,69 +71,30 @@ export class Stealthy {
     return false;
   }
 
-  static testVisionStealth(visionSource, config) {
-    const target = config.object?.actor;
-    const ignoreFriendlyStealth =
-      game.settings.get('stealthy', 'ignoreFriendlyStealth') &&
-      config.object.document?.disposition === visionSource.object.document?.disposition;
-
-    if (!ignoreFriendlyStealth) {
-      const hidden = target?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden") && !e.disabled);
-      if (hidden) {
-        // This will be better implemented as an interface
-        // First thing to do when adding second supported system
-        if (Stealthy.isHidden5e(visionSource, hidden, target, config)) return false;
-      }
+  static async rollPerception(actor, roll) {
+    const label = game.i18n.localize("stealthy-spot");
+    let spot = actor.effects.find(e => e.label === label);
+    if (!spot) {
+      const newEffect = [{
+        label,
+        icon: 'icons/magic/perception/eye-ringed-green.webp',
+        duration: { turns: 1, seconds: 6 },
+        flags: {
+          convenientDescription: game.i18n.localize("stealthy-spot-description"),
+          'stealthy.spot': Math.max(roll.total, actor.system.skills.prc.passive),
+        },
+      }];
+      await actor.createEmbeddedDocuments('ActiveEffect', newEffect);
     }
-
-    return true;
+    else {
+      let activeSpot = duplicate(spot);
+      activeSpot.flags['stealthy.spot'] = Math.max(roll.total, actor.system.skills.prc.passive);
+      activeSpot.disabled = false;
+      await actor.updateEmbeddedDocuments('ActiveEffect', [activeSpot]);
+    }
   }
-}
 
-Hooks.once('setup', () => {
-  libWrapper.register(
-    'stealthy',
-    "DetectionModeBasicSight.prototype.testVisibility",
-    (wrapped, visionSource, mode, config = {}) => {
-      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
-
-      const target = config.object?.actor;
-      let noDarkvision = false;
-      const ignoreFriendlyUmbralSight =
-        game.settings.get('stealthy', 'ignoreFriendlyUmbralSight') &&
-        config.object.document?.disposition === visionSource.object.document?.disposition;
-      if (!ignoreFriendlyUmbralSight && visionSource.visionMode?.id === 'darkvision') {
-        const umbralSight = target?.itemTypes?.feat?.find(f => f.name === game.i18n.localize('Umbral Sight'));
-        if (umbralSight) noDarkvision = true;
-      }
-
-      if (noDarkvision) {
-        Stealthy.log(`${visionSource.object.name}'s darkvision can't see ${config.object.name}`);
-        let ourMode = duplicate(mode);
-        ourMode.range = 0;
-        return wrapped(visionSource, ourMode, config);
-      }
-
-      return wrapped(visionSource, mode, config);
-    },
-    libWrapper.MIXED,
-    { perf_mode: libWrapper.PERF_FAST }
-  );
-
-  libWrapper.register(
-    'stealthy',
-    "DetectionModeInvisibility.prototype.testVisibility",
-    (wrapped, visionSource, mode, config = {}) => {
-      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
-      return wrapped(visionSource, mode, config);
-    },
-    libWrapper.MIXED,
-    { perf_mode: libWrapper.PERF_FAST }
-  );
-});
-
-Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
-  if (skill === 'ste') {
+  static async rollStealth(actor, roll) {
     const label = game.i18n.localize("stealthy-hidden");
     let hidden = actor.effects.find(e => e.label === label);
 
@@ -189,27 +151,74 @@ Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
     await actor.updateEmbeddedDocuments('ActiveEffect', [activeHide]);
   }
 
+  static testVisionStealth(visionSource, config) {
+    const target = config.object?.actor;
+    const ignoreFriendlyStealth =
+      game.settings.get('stealthy', 'ignoreFriendlyStealth') &&
+      config.object.document?.disposition === visionSource.object.document?.disposition;
+
+    if (!ignoreFriendlyStealth) {
+      const hidden = target?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden") && !e.disabled);
+      if (hidden) {
+        // This will be better implemented as an interface
+        // First thing to do when adding second supported system
+        if (Stealthy.isHidden5e(visionSource, hidden, target, config)) return false;
+      }
+    }
+
+    return true;
+  }
+
+}
+
+Hooks.once('setup', () => {
+  libWrapper.register(
+    'stealthy',
+    "DetectionModeBasicSight.prototype.testVisibility",
+    (wrapped, visionSource, mode, config = {}) => {
+      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
+
+      const target = config.object?.actor;
+      let noDarkvision = false;
+      const ignoreFriendlyUmbralSight =
+        game.settings.get('stealthy', 'ignoreFriendlyUmbralSight') &&
+        config.object.document?.disposition === visionSource.object.document?.disposition;
+      if (!ignoreFriendlyUmbralSight && visionSource.visionMode?.id === 'darkvision') {
+        const umbralSight = target?.itemTypes?.feat?.find(f => f.name === game.i18n.localize('Umbral Sight'));
+        if (umbralSight) noDarkvision = true;
+      }
+
+      if (noDarkvision) {
+        Stealthy.log(`${visionSource.object.name}'s darkvision can't see ${config.object.name}`);
+        let ourMode = duplicate(mode);
+        ourMode.range = 0;
+        return wrapped(visionSource, ourMode, config);
+      }
+
+      return wrapped(visionSource, mode, config);
+    },
+    libWrapper.MIXED,
+    { perf_mode: libWrapper.PERF_FAST }
+  );
+
+  libWrapper.register(
+    'stealthy',
+    "DetectionModeInvisibility.prototype.testVisibility",
+    (wrapped, visionSource, mode, config = {}) => {
+      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
+      return wrapped(visionSource, mode, config);
+    },
+    libWrapper.MIXED,
+    { perf_mode: libWrapper.PERF_FAST }
+  );
+});
+
+Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
+  if (skill === 'ste') {
+    await rollStealth(actor, roll);
+  }
   else if (skill === 'prc') {
-    const label = game.i18n.localize("stealthy-spot");
-    let spot = actor.effects.find(e => e.label === label);
-    if (!spot) {
-      const newEffect = [{
-        label,
-        icon: 'icons/magic/perception/eye-ringed-green.webp',
-        duration: { turns: 1 },
-        flags: {
-          convenientDescription: game.i18n.localize("stealthy-spot-description"),
-          'stealthy.spot': Math.max(roll.total, actor.system.skills.prc.passive),
-        },
-      }];
-      await actor.createEmbeddedDocuments('ActiveEffect', newEffect);
-    }
-    else {
-      let activeSpot = duplicate(spot);
-      activeSpot.flags['stealthy.spot'] = Math.max(roll.total, actor.system.skills.prc.passive);
-      activeSpot.disabled = false;
-      await actor.updateEmbeddedDocuments('ActiveEffect', [activeSpot]);
-    }
+    await rollPerception(actor, roll);
   }
 });
 

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -71,7 +71,10 @@ export class Stealthy {
     return false;
   }
 
+  static isCreatingSpotEffect = true;
+
   static async rollPerception(actor, roll) {
+    if (!Stealthy.isCreatingSpotEffect) return;
     const label = game.i18n.localize("stealthy-spot");
     let spot = actor.effects.find(e => e.label === label);
     if (!spot) {
@@ -215,10 +218,10 @@ Hooks.once('setup', () => {
 
 Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
   if (skill === 'ste') {
-    await rollStealth(actor, roll);
+    await Stealthy.rollStealth(actor, roll);
   }
   else if (skill === 'prc') {
-    await rollPerception(actor, roll);
+    await Stealthy.rollPerception(actor, roll);
   }
 });
 
@@ -249,4 +252,18 @@ Hooks.on("renderSettingsConfig", (app, html, data) => {
   $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-general")).insertBefore($('[name="stealthy.ignoreFriendlyStealth"]').parents('div.form-group:first'));
   $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-debug")).insertBefore($('[name="stealthy.logLevel"]').parents('div.form-group:first'));
   $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-experimental")).insertBefore($('[name="stealthy.tokenLighting"]').parents('div.form-group:first'));
+});
+
+Hooks.on("getSceneControlButtons", (controls) => {
+  if (!game.user.isGM) return;
+  let tokenControls = controls.find(x => x.name === "token");
+  tokenControls.tools.push({
+    icon: "fa-solid fa-eyes",
+    name: "stealthy-spotting",
+    title: game.i18n.localize("stealthy-spotting-toggle"),
+    toggle: true,
+    active: Stealthy.isCreatingSpotEffect,
+    onClick: (toggled) => Stealthy.isCreatingSpotEffect = toggled
+  });
+
 });

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -178,7 +178,7 @@ export class Stealthy {
 
     if (!toggled && game.user.isGM) {
       for (let actor of game.actors.contents) {
-        const spot = actor.effects.find(e => e.name = game.i18n.localize('stealthy-spot'));
+        const spot = actor.effects.find(e => e.label = game.i18n.localize('stealthy-spot'));
         if (spot) {
           actor.deleteEmbeddedDocuments('ActiveEffect', [spot.id]);
         }

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -173,8 +173,17 @@ export class Stealthy {
     return true;
   }
 
-  static toggleSpotting(toggled) {
+  static async toggleSpotting(toggled) {
     Stealthy.enableSpot = toggled;
+
+    if (!toggled && game.user.isGM) {
+      for (let actor of game.actors.contents) {
+        const spot = actor.effects.find(e => e.name = game.i18n.localize('stealthy-spot'));
+        if (spot) {
+          actor.deleteEmbeddedDocuments('ActiveEffect', [spot.id]);
+        }
+      }
+    }
   }
 
 }
@@ -273,7 +282,7 @@ Hooks.on("getSceneControlButtons", (controls) => {
     title: game.i18n.localize("stealthy-spotting-toggle"),
     toggle: true,
     active: Stealthy.enableSpot,
-    onClick: (toggled) => Stealthy.socket.executeForEveryone('toggleSpotting', toggled);
+    onClick: (toggled) => Stealthy.socket.executeForEveryone('toggleSpotting', toggled)
   });
 
 });

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -196,3 +196,8 @@ Hooks.on("renderTokenHUD", (tokenHUD, html, app) => {
     }
   }
 });
+
+Hooks.on("renderSettingsConfig", (app, html, data) => {
+  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-general")).insertBefore($('[name="stealthy.ignoreFriendlyStealth"]').parents('div.form-group:first'));
+  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-debug")).insertBefore($('[name="stealthy.logLevel"]').parents('div.form-group:first'));
+});

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -1,7 +1,7 @@
 export class Stealthy {
 
   static CONSOLE_COLORS = ['background: #222; color: #ff80ff', 'color: #fff'];
-  static lightNumTable  = ['dark','dim','bright'];
+  static lightNumTable = ['dark', 'dim', 'bright'];
 
   static log(format, ...args) {
     const level = game.settings.get('stealthy', 'logLevel');
@@ -41,25 +41,20 @@ export class Stealthy {
           // idea that active skills need to win outright to change the status quo. Passive
           // perception means that stealth is being the active skill.
           let perception = spot?.flags.stealthy?.spot ?? (source.system.skills.prc.passive + 1);
-          
+
           // check target Token Lighting conditions via effects usage
           // look for effects that indicate Dim or Dark condition on the token
-          const  tokenLight = game.settings.get('stealthy', 'tokenLighting');
-          if (tokenLight){
+          const tokenLight = game.settings.get('stealthy', 'tokenLighting');
+          if (tokenLight) {
             let lightLevel = 2;
-            let debugData = {
-              initlightLevel: "",
-              darklightLevel: "NA",
-              pass_prc: 0,
-              post_pass_prc: 0
-            }   
+            let debugData = {};
 
-            if (target?.effects.find(e => e.label === 'Dark' && !e.disabled)){lightLevel=0;}
-            if (target?.effects.find(e => e.label === 'Dim' && !e.disabled)){lightLevel=1;}
+            if (target?.effects.find(e => e.label === 'Dark' && !e.disabled)) { lightLevel = 0; }
+            if (target?.effects.find(e => e.label === 'Dim' && !e.disabled)) { lightLevel = 1; }
             debugData.initlightLevel = Stealthy.lightNumTable[lightLevel];
 
             // check if Darkvision is in use, bump light level accordingly
-            if (visionSource.visionMode?.id === 'darkvision'){
+            if (visionSource.visionMode?.id === 'darkvision') {
               lightLevel = lightLevel + 1;
               debugData.darklightLevel = Stealthy.lightNumTable[lightLevel];
             }
@@ -67,8 +62,8 @@ export class Stealthy {
             // adjust passive perception depending on light conditions of target token
             // don't adjust for active perception checks via 'spot' flag usage
             debugData.pass_prc = perception;
-            if (lightLevel<2 && !spot?.flags.stealthy?.spot){
-              perception = perception-5;
+            if (lightLevel < 2 && !spot?.flags.stealthy?.spot) {
+              perception = perception - 5;
             };
             debugData.post_pass_prc = perception;
 
@@ -76,6 +71,7 @@ export class Stealthy {
           }
 
           if (perception <= stealth) {
+            Stealthy.log(`${visionSource.object.name}'s ${perception} can't see ${config.object.name}'s ${stealth}`);
             return false;
           }
         }
@@ -104,6 +100,7 @@ Hooks.once('setup', () => {
       }
 
       if (noDarkvision) {
+        Stealthy.log(`${visionSource.object.name}'s darkvision can't see ${config.object.name}`);
         let ourMode = duplicate(mode);
         ourMode.range = 0;
         return wrapped(visionSource, ourMode, config);


### PR DESCRIPTION
# Version 1.5.1
* Fixed incorrect name use when toggling Spot

# Version 1.5.0
* Added socketlib as a required module
* Added token control for GM to toggle Spot effect generation across all clients
* Added optional Logging when objects are filtered out by Stealthy
* Better code organization
* Grouped related settings in the settings dialog
* Experimental: option for perception checks to be affected by Dim or Dark status conditions on the token. Only affect passive perception currently.