### PR TITLE
Pf1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,9 @@
 * Built proper interface for stealth engine
   - dnd5e: fully encapsulated
   - pf2e: need to adapt the active effects to the PF2e system implementation
-  - pf1: stubbed
+  - pf1: actually seems to "work"
+    - I assume take-10 perception for tokens without an active spot effect. It isn't RAW, but perhaps this is acceptable to the PF1 community.
+    - the PF1 actor sheet UI doesn't seem to have a way to delete the effects once they've been added by rolling
 * Experimental: Convert Perception roll results into roll pairs for Spot, rolling an extra die if needed
 * Experimental: Implement Dim/Dark flag effects on Perception tests using Foundry darkvision model
 

--- a/scripts/systems/pf1.js
+++ b/scripts/systems/pf1.js
@@ -1,5 +1,9 @@
 import { Stealthy, StealthyBaseEngine } from '../stealthy.js';
 
+// This mechanically works, but I don't know how one is supposed to get rid
+// of the Hidden effect once it is placed given the PF1 UI doesn't seem to show
+// active effects.
+
 export class StealthyPF1 extends StealthyBaseEngine {
 
   constructor() {

--- a/scripts/systems/pf1.js
+++ b/scripts/systems/pf1.js
@@ -3,53 +3,111 @@ import { Stealthy, StealthyBaseEngine } from '../stealthy.js';
 export class StealthyPF1 extends StealthyBaseEngine {
 
   constructor() {
-    // Hook the relevant skills to capture spot and hidden test
-    // results into effects on the actor.
     super();
-    console.warn(`Stealthy for '${game.system.id}' is stubbed out, needs development`);
+
+    Hooks.on('pf1ActorRollSkill', async (actor, message, skill) => {
+      if (skill === 'ste') {
+        await this.rollStealth(actor, message);
+      }
+      else if (skill === 'per') {
+        await this.rollPerception(actor, message);
+      }
+    });
   }
 
   isHidden(visionSource, hidden, target, config) {
-    // Implement your system's method for testing spot data vs hidden data
-    // This should would in the absence of a spot effect on the viewer, using
-    // a passive or default value as necessary
+    const source = visionSource.object?.actor;
+    const stealth = hidden.flags.stealthy?.hidden ?? (10 + target.system.skills.ste.mod);
+    const spot = source?.effects.find(e => e.label === game.i18n.localize("stealthy-spot-label") && !e.disabled);
+    const perception = spot?.flags.stealthy?.spot ?? (10 + target.system.skills.per.mod);
+
+    if (perception <= stealth) {
+      Stealthy.log(`${visionSource.object.name}'s ${perception} can't see ${config.object.name}'s ${stealth}`);
+      return true;
+    }
     return false;
   }
 
-  basicVision(wrapped, visionSource, mode, config) {
-    // Any special filtering beyond stealth testing is handled here, like being invisible to darkvision/etc.
-    return wrapped(visionSource, mode, config);
-  }
-
-  seeInvisibility(wrapped, visionSource, mode, config) {
-    // Any special filtering beyond stealth testing is handled here.
-    return wrapped(visionSource, mode, config);
-  }
-
   getHiddenFlagAndValue(hidden) {
-    // Return the data necessary for storing data about hidden, and the
-    // value that should be shown on the token button input
-    return { flag: { hidden: undefined }, value: undefined };
+    const value = hidden.flags.stealthy?.hidden ?? actor.system.skills.ste.value;
+    return { flag: { hidden: value }, value };
   }
 
   async setHiddenValue(actor, effect, flag, value) {
-    // If the hidden value was changed, do what you need to store it
     flag.hidden = value;
     effect.flags.stealthy = flag;
     await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
   }
 
   getSpotFlagAndValue(spot) {
-    // Return the data necessary for storing data about spot, and the
-    // value that should be shown on the token button input
-    return { flag: { spot: undefined }, value: undefined };
+    const value = spot.flags.stealthy?.spot ?? actor.system.attributes.perception.value;
+    return { flag: { spot: value }, value };
   }
 
   async setSpotValue(actor, effect, flag, value) {
-    // If the spot value was changed, do what you need to store it
     flag.spot = value;
     effect.flags.stealthy = flag;
     await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
+  }
+
+  async rollPerception(actor, message) {
+    Stealthy.log('rollPerception', { actor, message });
+
+    const label = game.i18n.localize("stealthy-spot-label");
+    await this.updateOrCreateEffect({
+      label,
+      actor,
+      flag: { spot: message.rolls[0].total },
+      makeEffect: (flag, source) => ({
+        label,
+        icon: 'icons/commodities/biological/eye-blue.webp',
+        duration: { turns: 1, seconds: 6 },
+        flags: {
+          convenientDescription: game.i18n.localize("stealthy-spot-description"),
+          stealthy: flag
+        },
+      })
+    });
+  }
+
+  async rollStealth(actor, message) {
+    Stealthy.log('rollStealth', { actor, message });
+
+    const label = game.i18n.localize("stealthy-hidden-label");
+    await this.updateOrCreateEffect({
+      label,
+      actor,
+      flag: { hidden: message.rolls[0].total },
+      makeEffect: (flag, source) => {
+        let hidden = {
+          label,
+          icon: 'icons/magic/perception/shadow-stealth-eyes-purple.webp',
+          changes: [],
+          flags: {
+            convenientDescription: game.i18n.localize("stealthy-hidden-description"),
+            stealthy: flag,
+            core: { statusId: '1' },
+          },
+        };
+        if (source === 'ae') {
+          if (typeof TokenMagic !== 'undefined') {
+            hidden.changes.push({
+              key: 'macro.tokenMagic',
+              mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+              value: 'fog'
+            });
+          }
+          else if (typeof ATLUpdate !== 'undefined') {
+            hidden.changes.push({
+              key: 'ATL.alpha',
+              mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+              value: '0.5'
+            });
+          }
+        }
+        return hidden;
+      }
+    });
   }
 }
 


### PR DESCRIPTION
pf1: actually seems to "work"
- I assume take-10 perception for tokens without an active spot effect. It isn't RAW, but perhaps this is acceptable to the PF1 community.
- the PF1 actor sheet UI doesn't seem to have a way to delete the effects once they've been added by rolling
