### PR TITLE
v2.0.0

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "githubPullRequests.ignoredPullRequestBranches": [
+    "dev"
+  ]
+}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
 # Pending
-* EXP: Generate normal/disadvantage results in Spot effect for all Perception rolls
-* EXP: Implement Dim/Dark flag effects on Perception checks for Foundry darkvision model
+* Built proper interface for dnd5e stealth engine, built stubs for pf1 and pf2e
+* Experimental: Convert Perception roll results into roll pairs for Spot, rolling an extra die if needed
+* Experimental: Implement Dim/Dark flag effects on Perception tests using Foundry darkvision model
 
 # v1.6.1
 * Fixed error creating default spot effect

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# Pending
+* EXP: Generate normal/disadvantage results in Spot effect for all Perception rolls
+* EXP: Implement Dim/Dark flag effects on Perception checks for Foundry darkvision model
+
 # v1.6.1
 * Fixed error creating default spot effect
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,9 @@
 * Built proper interface for stealth engine
   - dnd5e: fully encapsulated
   - pf2e: need to adapt the active effects to the PF2e system implementation
-  - pf1: stubbed
+  - pf1: actually seems to "work"
+    - I assume take-10 perception for tokens without an active spot effect. It isn't RAW, but perhaps this is acceptable to the PF1 community.
+    - the PF1 actor sheet UI doesn't seem to have a way to delete the effects once they've been added by rolling
 * Experimental: Convert Perception roll results into roll pairs for Spot, rolling an extra die if needed
 * Experimental: Implement Dim/Dark flag effects on Perception tests using Foundry darkvision model
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,12 +1,8 @@
-# Pending
-* Built proper interface for stealth engine
-  - dnd5e: fully encapsulated
-  - pf2e: need to adapt the active effects to the PF2e system implementation
-  - pf1: actually seems to "work"
-    - I assume take-10 perception for tokens without an active spot effect. It isn't RAW, but perhaps this is acceptable to the PF1 community.
-    - the PF1 actor sheet UI doesn't seem to have a way to delete the effects once they've been added by rolling
-* Experimental: Convert Perception roll results into roll pairs for Spot, rolling an extra die if needed
-* Experimental: Implement Dim/Dark flag effects on Perception tests using Foundry darkvision model
+# v2.0.0
+* PF1 support - effect cleanup is macro based so buyer beware
+* PF2e support parked due to active effect incompatibility
+* Experimental: Converted Perception roll results into roll pairs for Spot, rolling an extra die if needed
+* Experimental: Dim and Hidden conditions on viewed token applies disadvantage to Perception during visibility test
 
 # v1.6.1
 * Fixed error creating default spot effect

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # Pending
-* Built proper interface for dnd5e stealth engine, built stubs for pf1 and pf2e
+* Built proper interface for stealth engine
+  - dnd5e: fully encapsulated
+  - pf2e: need to adapt the active effects to the PF2e system implementation
+  - pf1: stubbed
 * Experimental: Convert Perception roll results into roll pairs for Spot, rolling an extra die if needed
 * Experimental: Implement Dim/Dark flag effects on Perception tests using Foundry darkvision model
 

--- a/README.md
+++ b/README.md
@@ -22,11 +22,13 @@ Rolling a Stealth skill check will apply the Hidden condition to the actor and r
 ![stealth-roll](https://user-images.githubusercontent.com/16523503/209989026-e0d2dad2-8dc1-459c-8824-a2332ce8a9cd.gif)
 
 ### **Rolling Perception checks applies the Spot condition**
-Rolling a Perception check will add a one turn/six second duration Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor). The duration isn't from RAW, but is an approximation I've chosen that seems to work well in my games.
-
-*The initial stored Perception value from the roll uses passive Perception as a floor.*
+Rolling a Perception check will add a Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor).
 
 A toggle named 'Active Spot' is available under token controls to suspend adding of the Spot condition as the GM sees fit. Toggling it off will also clear out all Spot effects.
+
+- dnd5e
+  - Stealthy's default Spot effect has a one turn/six second duration. This isn't from RAW, but is an approximation I've chosen that seems to work well in my games.
+  - The initial stored Perception value from the roll uses passive Perception as a floor.*
 
 ![perception](https://user-images.githubusercontent.com/16523503/209989470-aac2bdb4-fee4-44c0-a6b7-916e69353081.gif)
 ![control](https://user-images.githubusercontent.com/16523503/210176825-3fcb3183-81db-4f64-836a-81f29199b580.png)
@@ -36,7 +38,7 @@ Once the Hidden or Spot conditions are applied, GMs will see token buttons with 
 
 ![stealth-override](https://user-images.githubusercontent.com/16523503/209896031-675ab0e3-93e6-4d9c-8eeb-c11abe39fdab.gif)
 
-### **Umbral Sight affects darkvision**
+### **dnd5e: Umbral Sight affects darkvision**
 Characters with Umbral Sight will no longer be visible to the Darkvision mode, but they can still be seen if Basic Vision can see them. The GM has the option to disable this for friendly token visibility tests.
 
 ![umbral-sight](https://user-images.githubusercontent.com/16523503/209987083-487aee33-b75e-452f-9433-7302ffdaeab3.gif)
@@ -50,14 +52,18 @@ An invisible actor that also has the 'Hidden' condition will check Perception vs
 The GM has the option for allowing Hidden tokens to be seen by other tokens of the same disposition.
 
 ## Handling Hidden removal
-Stealthy will not automatically remove the Hidden condition - the [Skulker](https://www.dndbeyond.com/feats/skulker) feat demonstrates why removing Hidden gets complicated without heavier automation support provided by modules like the excellent [Midi-QOL](https://foundryvtt.com/packages/midi-qol) which handles this for my games. I suggest [DFreds Effects Panel](https://foundryvtt.com/packages/dfreds-effects-panel) as an easier way to manually remove it, especially for low automation level games. 
-## Stealth vs Perception Ties
+Stealthy will not automatically remove the Hidden condition - the dnd5e [Skulker](https://www.dndbeyond.com/feats/skulker) feat demonstrates why removing Hidden gets complicated without heavier automation support provided by modules like the excellent [Midi-QOL](https://foundryvtt.com/packages/midi-qol) which handles this for my games. I suggest [DFreds Effects Panel](https://foundryvtt.com/packages/dfreds-effects-panel) as an easier way to manually remove it, especially for low automation level games. 
+
+## dnd5e: Stealth vs Perception Ties
 D&D 5E treats skill contest ties as preserving the status quo, so use of passive value for either skill makes a claim of owning the status quo and thus winning ties. If Perception and Stealth are both passive, I assume Stealth takes the active role of wanting to change the status quo from visible to hidden. An active Perception check is only necessary if the passive Perception was beaten by Stealth, so in this case Hidden is now the status quo condition and Stealth wins ties with the active result. More simply, **ties are won by passive Perception and lost by active Perception.**
+
+## Other systems
+I've isolated out all the specific dnd5e code I wrote into its own engine object, and have put in stubs for pf1 and pf2e as well, although I am unlikely to fill these out as I don't have active games using them. I'd be happy to take any help offered to make Stealty work in other systems!
 
 ## Experimental
 
 ### Lighting effects on Perception vs Hidden token
-For this approach we've broken this down into three pieces:
+For this approach we are only looking at dnd5e and we've broken this down into three pieces:
 - Detecting the light level on the token itself, which is independant of viewer. Stealthy is decoupled from figuring that out by just looking for 'Dim' or 'Dark' conditions on the token; a different module will manage this. Fingers crossed.
 - Remapping the dim/dark light level per viewer based on their viewing mode. At least 3 different mapping tables are needed:
   - Foundry Darkvision: Dark -> Dim; Dim -> Bright **(Current Implementation)**

--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ Stealthy will not automatically remove the Hidden condition - the dnd5e [Skulker
 D&D 5E treats skill contest ties as preserving the status quo, so use of passive value for either skill makes a claim of owning the status quo and thus winning ties. If Perception and Stealth are both passive, I assume Stealth takes the active role of wanting to change the status quo from visible to hidden. An active Perception check is only necessary if the passive Perception was beaten by Stealth, so in this case Hidden is now the status quo condition and Stealth wins ties with the active result. More simply, **ties are won by passive Perception and lost by active Perception.**
 
 ## Other systems
-I've isolated out all the specific dnd5e code I wrote into its own engine object, and have put in stubs for pf1 and pf2e as well, although I am unlikely to fill these out as I don't have active games using them. I'd be happy to take any help offered to make Stealthy work in other systems! Stealth engines don't have to live inside Stealthy's codebase - they can be added externally like below:
+- PF1 sort of works!
+  - I assume take-10 perception for tokens without an active spot effect. It isn't RAW, but perhaps this is acceptable to the PF1 community.
+  - the PF1 actor sheet UI doesn't seem to have a way to delete the effects once they've been added by rolling
+- PF2e seems to have completely replaced the Active Effect system which Stealthy uses as its backbone, so some heavy lifting has to be done to adapt it.
+
+I've isolated out all the specific dnd5e code I wrote into its own engine object and built a sort-of working implementation for PF1 - see changelog for caveats. I'd be happy to take any help offered to make Stealthy work in other systems! Stealth engines don't have to live inside Stealthy's codebase - they can be added externally like below:
 ```
 Hooks.once('init', () => {
   Stealthy.RegisterEngine('pf1', () => new StealthyPF1());

--- a/README.md
+++ b/README.md
@@ -56,13 +56,16 @@ D&D 5E treats skill contest ties as preserving the status quo, so use of passive
 
 ## Experimental
 
-### Check token lighting conditions
-This option triggers a check for the following effects on the target token:
-- Dark
-- Dim
+### Lighting effects on Perception vs Hidden token
+For this approach we've broken this down into three pieces:
+- Detecting the light level on the token itself, which is independant of viewer. Stealthy is decoupled from figuring that out by just looking for 'Dim' or 'Dark' conditions on the token; a different module will manage this. Fingers crossed.
+- Remapping the dim/dark light level per viewer based on their viewing mode. At least 3 different mapping tables are needed:
+  - RAW 5E Darkvision: Dark -> Dim
+  - Foundry Darkvision: Dark -> Dim; Dim -> Bright
+  - Demonsight: Dark -> Bright
 
-IF the target token has these effects, then the passive perception check will be adjusted accordingly.
-This takes Darkvision into account for light conditions ( light level bump ) before determining passive perception adjustment.
+  After the light level is remapped, objects in 'Dark' don't get drawn and objects in 'Dim' would be tested against using disadvantaged perception.
+- Capturing the advantage/disadvantage state of the viewers perception in order to do the right thing when applying disadvantage in dim vision. We get these flags on the active rolls, and can generate an extra roll result we can store in our flag so that we have a result for disadvantage should we need it. The passive case could maybe be figured out by doing a silent rollSkill call for perception to see what flags were set.
 
 ## Required modules
 * [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper)

--- a/README.md
+++ b/README.md
@@ -60,12 +60,12 @@ D&D 5E treats skill contest ties as preserving the status quo, so use of passive
 For this approach we've broken this down into three pieces:
 - Detecting the light level on the token itself, which is independant of viewer. Stealthy is decoupled from figuring that out by just looking for 'Dim' or 'Dark' conditions on the token; a different module will manage this. Fingers crossed.
 - Remapping the dim/dark light level per viewer based on their viewing mode. At least 3 different mapping tables are needed:
+  - Foundry Darkvision: Dark -> Dim; Dim -> Bright **(Current Implementation)**
   - RAW 5E Darkvision: Dark -> Dim
-  - Foundry Darkvision: Dark -> Dim; Dim -> Bright
   - Demonsight: Dark -> Bright
 
-  After the light level is remapped, objects in 'Dark' don't get drawn and objects in 'Dim' would be tested against using disadvantaged perception.
-- Capturing the advantage/disadvantage state of the viewers perception in order to do the right thing when applying disadvantage in dim vision. We get these flags on the active rolls, and can generate an extra roll result we can store in our flag so that we have a result for disadvantage should we need it. The passive case could maybe be figured out by doing a silent rollSkill call for perception to see what flags were set.
+  After the light level is remapped, objects in 'Dark' get rejected and objects in 'Dim' would be tested against using disadvantaged perception.
+- Capturing the advantage/disadvantage state of the viewers perception in order to do the right thing when applying disadvantage in dim vision. We get these flags on the active rolls, and can generate an extra roll result we can store in our flag so that we have a result for disadvantage should we need it. **We don't have a cost-effective way to figure out pre-existing passive disadvantage on perception, so this edge case will cause those tokens to end up taking the -5 penalty twice. You have been warned.**
 
 ## Required modules
 * [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper)

--- a/README.md
+++ b/README.md
@@ -58,7 +58,12 @@ Stealthy will not automatically remove the Hidden condition - the dnd5e [Skulker
 D&D 5E treats skill contest ties as preserving the status quo, so use of passive value for either skill makes a claim of owning the status quo and thus winning ties. If Perception and Stealth are both passive, I assume Stealth takes the active role of wanting to change the status quo from visible to hidden. An active Perception check is only necessary if the passive Perception was beaten by Stealth, so in this case Hidden is now the status quo condition and Stealth wins ties with the active result. More simply, **ties are won by passive Perception and lost by active Perception.**
 
 ## Other systems
-I've isolated out all the specific dnd5e code I wrote into its own engine object, and have put in stubs for pf1 and pf2e as well, although I am unlikely to fill these out as I don't have active games using them. I'd be happy to take any help offered to make Stealthy work in other systems!
+I've isolated out all the specific dnd5e code I wrote into its own engine object, and have put in stubs for pf1 and pf2e as well, although I am unlikely to fill these out as I don't have active games using them. I'd be happy to take any help offered to make Stealthy work in other systems! Stealth engines don't have to live inside Stealthy's codebase - they can be added externally like below:
+```
+Hooks.once('init', () => {
+  Stealthy.RegisterEngine('pf1', () => new StealthyPF1());
+});
+```
 
 ## Experimental
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Stealthy will not automatically remove the Hidden condition - the dnd5e [Skulker
 D&D 5E treats skill contest ties as preserving the status quo, so use of passive value for either skill makes a claim of owning the status quo and thus winning ties. If Perception and Stealth are both passive, I assume Stealth takes the active role of wanting to change the status quo from visible to hidden. An active Perception check is only necessary if the passive Perception was beaten by Stealth, so in this case Hidden is now the status quo condition and Stealth wins ties with the active result. More simply, **ties are won by passive Perception and lost by active Perception.**
 
 ## Other systems
-I've isolated out all the specific dnd5e code I wrote into its own engine object, and have put in stubs for pf1 and pf2e as well, although I am unlikely to fill these out as I don't have active games using them. I'd be happy to take any help offered to make Stealty work in other systems!
+I've isolated out all the specific dnd5e code I wrote into its own engine object, and have put in stubs for pf1 and pf2e as well, although I am unlikely to fill these out as I don't have active games using them. I'd be happy to take any help offered to make Stealthy work in other systems!
 
 ## Experimental
 

--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@
 
 A module for [FoundryVTT](https://foundryvtt.com) that adds perception vs stealth testing to Foundry's visibility tests.
 
-## Purpose
+# Purpose
 
 During visibility tests, Stealthy filters out any objects with the Hidden condition if the viewing Perception value fails to beat the object's Stealth value.
 
 ## Features
 
-### **Rolling Stealth checks applies the Hidden condition**
+## **Rolling Stealth checks applies the Hidden condition**
 Rolling a Stealth skill check will apply the Hidden condition to the actor and record the result of the check in that condition for later comparisons, replacing the stored result if the Hidden condition is already present. Stealthy's default Hidden effect can be overriden by adding a custom Hidden effect in either Convenient Effects or CUB.
 
 ***See [Handling Hidden removal](#handling-hidden-removal)***
 
 ![stealth-roll](https://user-images.githubusercontent.com/16523503/209989026-e0d2dad2-8dc1-459c-8824-a2332ce8a9cd.gif)
 
-### **Rolling Perception checks applies the Spot condition**
+## **Rolling Perception checks applies the Spot condition**
 Rolling a Perception check will add a Spot condition to the actor which records the result of that perception check (the passive value for Perception is used if this condition isn't present on the actor).
 
 A toggle named 'Active Spot' is available under token controls to suspend adding of the Spot condition as the GM sees fit. Toggling it off will also clear out all Spot effects.
@@ -33,46 +33,44 @@ A toggle named 'Active Spot' is available under token controls to suspend adding
 ![perception](https://user-images.githubusercontent.com/16523503/209989470-aac2bdb4-fee4-44c0-a6b7-916e69353081.gif)
 ![control](https://user-images.githubusercontent.com/16523503/210176825-3fcb3183-81db-4f64-836a-81f29199b580.png)
 
-### **GM Overrides**
+## **GM Overrides**
 Once the Hidden or Spot conditions are applied, GMs will see token buttons with an input box on the bottom which shows the rolled values, or the passive values if the condition was added directly without rolling. Perception is on the left, Stealth is on the right. Changing the value in this input box will alter the stored results for future visibility tests while that condition remains.
 
 ![stealth-override](https://user-images.githubusercontent.com/16523503/209896031-675ab0e3-93e6-4d9c-8eeb-c11abe39fdab.gif)
 
-### **dnd5e: Umbral Sight affects darkvision**
+## **dnd5e: Umbral Sight affects darkvision**
 Characters with Umbral Sight will no longer be visible to the Darkvision mode, but they can still be seen if Basic Vision can see them. The GM has the option to disable this for friendly token visibility tests.
 
 ![umbral-sight](https://user-images.githubusercontent.com/16523503/209987083-487aee33-b75e-452f-9433-7302ffdaeab3.gif)
 
-### **Invisible characters can hide from See Invisibility**
+## **Invisible characters can hide from See Invisibility**
 An invisible actor that also has the 'Hidden' condition will check Perception vs Stealth before showing up in the 'See Invisibility' vision mode.
 
 ![invisible](https://user-images.githubusercontent.com/16523503/210176827-03fda57a-6d09-4144-8253-b8b7cd9155ac.gif)
 
-### **Friendly tokens can still be viewed**
+## **Friendly tokens can still be viewed**
 The GM has the option for allowing Hidden tokens to be seen by other tokens of the same disposition.
+
+# Limitations
 
 ## Handling Hidden removal
 Stealthy will not automatically remove the Hidden condition - the dnd5e [Skulker](https://www.dndbeyond.com/feats/skulker) feat demonstrates why removing Hidden gets complicated without heavier automation support provided by modules like the excellent [Midi-QOL](https://foundryvtt.com/packages/midi-qol) which handles this for my games. I suggest [DFreds Effects Panel](https://foundryvtt.com/packages/dfreds-effects-panel) as an easier way to manually remove it, especially for low automation level games. 
 
-## dnd5e: Stealth vs Perception Ties
-D&D 5E treats skill contest ties as preserving the status quo, so use of passive value for either skill makes a claim of owning the status quo and thus winning ties. If Perception and Stealth are both passive, I assume Stealth takes the active role of wanting to change the status quo from visible to hidden. An active Perception check is only necessary if the passive Perception was beaten by Stealth, so in this case Hidden is now the status quo condition and Stealth wins ties with the active result. More simply, **ties are won by passive Perception and lost by active Perception.**
+## Visibility changes are only reflected on token updates
+The visibility results are cached, so changes in visibility brought about by making skill checks, adjusting the result values manually, or removing the Spot/Hidden effects don't immediately change the visible state. This means sometimes you have force a token update by moving the token or selecting a different token. 
 
-## Other systems
-- PF1 sort of works!
-  - I assume take-10 perception for tokens without an active spot effect. It isn't RAW, but perhaps this is acceptable to the PF1 community.
-  - the PF1 actor sheet UI doesn't seem to have a way to delete the effects once they've been added by rolling
-- PF2e seems to have completely replaced the Active Effect system which Stealthy uses as its backbone, so some heavy lifting has to be done to adapt it.
-
+# Systems
 I've isolated out all the specific dnd5e code I wrote into its own engine object and built a sort-of working implementation for PF1 - see changelog for caveats. I'd be happy to take any help offered to make Stealthy work in other systems! Stealth engines don't have to live inside Stealthy's codebase - they can be added externally like below:
 ```
 Hooks.once('init', () => {
   Stealthy.RegisterEngine('pf1', () => new StealthyPF1());
 });
 ```
+## dnd5e
+### Stealth vs Perception Ties
+D&D 5E treats skill contest ties as preserving the status quo, so use of passive value for either skill makes a claim of owning the status quo and thus winning ties. If Perception and Stealth are both passive, I assume Stealth takes the active role of wanting to change the status quo from visible to hidden. An active Perception check is only necessary if the passive Perception was beaten by Stealth, so in this case Hidden is now the status quo condition and Stealth wins ties with the active result. More simply, **ties are won by passive Perception and lost by active Perception.**
 
-## Experimental
-
-### Lighting effects on Perception vs Hidden token
+### Experimental - Lighting effects on Perception vs Hidden token
 For this approach we are only looking at dnd5e and we've broken this down into three pieces:
 - Detecting the light level on the token itself, which is independant of viewer. Stealthy is decoupled from figuring that out by just looking for 'Dim' or 'Dark' conditions on the token; a different module will manage this. Fingers crossed.
 - Remapping the dim/dark light level per viewer based on their viewing mode. At least 3 different mapping tables are needed:
@@ -83,7 +81,28 @@ For this approach we are only looking at dnd5e and we've broken this down into t
   After the light level is remapped, objects in 'Dark' get rejected and objects in 'Dim' would be tested against using disadvantaged perception.
 - Capturing the advantage/disadvantage state of the viewers perception in order to do the right thing when applying disadvantage in dim vision. We get these flags on the active rolls, and can generate an extra roll result we can store in our flag so that we have a result for disadvantage should we need it. **We don't have a cost-effective way to figure out pre-existing passive disadvantage on perception, so this edge case will cause those tokens to end up taking the -5 penalty twice. You have been warned.**
 
-## Required modules
+## pf1
+  - I assume take-10 perception for tokens without an active spot effect. It isn't RAW, but perhaps this is acceptable to the PF1 community.
+  - the PF1 actor sheet UI doesn't seem to have a way to delete the effects once they've been added by rolling, so I made this macro (I assume there is a smarter way)
+
+'Remove Hidden' Script Macro:
+```
+const controlled = canvas.tokens.controlled;
+const label = game.i18n.localize('stealthy-hidden-label');
+controlled.forEach(token => {
+  const actor = token.actor;
+  const effects = actor.effects.filter(e => e.label === label).map(e => e.id);
+  if (effects.length > 0) {
+    actor.deleteEmbeddedDocuments('ActiveEffect', effects);
+  }
+});
+```
+*Remove Spot is the same with a 'stealthy-spot-label' substitution*
+
+## pf2e
+PF2e seems to have completely replaced the Active Effect system which Stealthy uses as its backbone, so some heavy lifting has to be done to finish adapting it.
+
+# Required modules
 * [lib-wrapper](https://foundryvtt.com/packages/lib-wrapper)
 * [socketlib](https://github.com/manuelVo/foundryvtt-socketlib)
 ## Optional modules

--- a/lang/en.json
+++ b/lang/en.json
@@ -26,5 +26,7 @@
   "stealthy-tokenLighting-name": "Check token lighting conditions",
   "stealthy-tokenLighting-hint": "Check for token effects that indicate lighting condition of the token. WARNING - only currently handles passive perception",
   "stealthy-dark-label": "Dark",
-  "stealthy-dim-label": "Dim"
+  "stealthy-dim-label": "Dim",
+  "stealthy-spotPair-name": "Roll second Perception die",
+  "stealthy-spotPair-hint": "Parse Perception roll results to have both a normal and disadvantaged result, rolling a second die if necessary"
 }

--- a/module.json
+++ b/module.json
@@ -37,7 +37,10 @@
     "scripts/config.js",
     "scripts/stealthy.js",
     "scripts/hooks.js",
-    "scripts/patches.js"
+    "scripts/patches.js",
+    "scripts/systems/dnd5e.js",
+    "scripts/systems/pf1.js",
+    "scripts/systems/pf2e.js"
   ],
   "languages": [
     {

--- a/module.json
+++ b/module.json
@@ -35,7 +35,9 @@
   },
   "esmodules": [
     "scripts/config.js",
-    "scripts/stealthy.js"
+    "scripts/stealthy.js",
+    "scripts/hooks.js",
+    "scripts/patches.js"
   ],
   "languages": [
     {

--- a/module.json
+++ b/module.json
@@ -12,7 +12,7 @@
       "flags": {}
     }
   ],
-  "version": "1.6.1",
+  "version": "2.0.0",
   "compatibility": {
     "minimum": "10.291",
     "verified": "10.291"
@@ -33,6 +33,10 @@
       }
     ]
   },
+  "system": [
+    "dnd5e",
+    "pf1"
+  ],
   "esmodules": [
     "scripts/config.js",
     "scripts/stealthy.js",
@@ -51,7 +55,7 @@
     }
   ],
   "socket": true,
-  "download": "https://github.com/Eligarf/stealthy/releases/download/v1.6.1/stealthy.zip",
+  "download": "https://github.com/Eligarf/stealthy/releases/download/v2.0.0/stealthy.zip",
   "changelog": "https://raw.githubusercontent.com/eligarf/stealthy/release/ChangeLog.md",
   "url": "https://github.com/Eligarf/stealthy",
   "manifest": "https://github.com/Eligarf/stealthy/releases/latest/download/module.json",

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -69,5 +69,20 @@ Hooks.once('ready', () => {
     default: false,
   });
 
+  game.settings.register('stealthy', 'spotPair', {
+    name: game.i18n.localize("stealthy-spotPair-name"),
+    hint: game.i18n.localize("stealthy-spotPair-hint"),
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+
   Stealthy.log(`Initialized ${moduleVersion}`);
+});
+
+Hooks.on('renderSettingsConfig', (app, html, data) => {
+  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-general")).insertBefore($('[name="stealthy.ignoreFriendlyStealth"]').parents('div.form-group:first'));
+  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-debug")).insertBefore($('[name="stealthy.logLevel"]').parents('div.form-group:first'));
+  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-experimental")).insertBefore($('[name="stealthy.tokenLighting"]').parents('div.form-group:first'));
 });

--- a/scripts/config.js
+++ b/scripts/config.js
@@ -14,14 +14,16 @@ Hooks.once('ready', () => {
     default: true,
   });
 
-  game.settings.register('stealthy', 'ignoreFriendlyUmbralSight', {
-    name: game.i18n.localize("stealthy-ignoreFriendlyUmbralSight-name"),
-    hint: game.i18n.localize("stealthy-ignoreFriendlyUmbralSight-hint"),
-    scope: 'world',
-    config: true,
-    type: Boolean,
-    default: false,
-  });
+  if (game.system.id === 'dnd5e') {
+    game.settings.register('stealthy', 'ignoreFriendlyUmbralSight', {
+      name: game.i18n.localize("stealthy-ignoreFriendlyUmbralSight-name"),
+      hint: game.i18n.localize("stealthy-ignoreFriendlyUmbralSight-hint"),
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: false,
+    });
+  }
 
   let sources = {
     'none': game.i18n.localize("stealthy-source-min"),
@@ -60,23 +62,25 @@ Hooks.once('ready', () => {
     default: 'none'
   });
 
-  game.settings.register('stealthy', 'tokenLighting', {
-    name: game.i18n.localize("stealthy-tokenLighting-name"),
-    hint: game.i18n.localize("stealthy-tokenLighting-hint"),
-    scope: 'world',
-    config: true,
-    type: Boolean,
-    default: false,
-  });
+  if (game.system.id === 'dnd5e') {
+    game.settings.register('stealthy', 'tokenLighting', {
+      name: game.i18n.localize("stealthy-tokenLighting-name"),
+      hint: game.i18n.localize("stealthy-tokenLighting-hint"),
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: false,
+    });
 
-  game.settings.register('stealthy', 'spotPair', {
-    name: game.i18n.localize("stealthy-spotPair-name"),
-    hint: game.i18n.localize("stealthy-spotPair-hint"),
-    scope: 'world',
-    config: true,
-    type: Boolean,
-    default: false,
-  });
+    game.settings.register('stealthy', 'spotPair', {
+      name: game.i18n.localize("stealthy-spotPair-name"),
+      hint: game.i18n.localize("stealthy-spotPair-hint"),
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: false,
+    });
+  }
 
   Stealthy.log(`Initialized ${moduleVersion}`);
 });

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -1,17 +1,9 @@
 import { Stealthy } from "./stealthy.js";
-import { Stealthy5e } from "./systems/dnd5e.js";
-import { StealthyPF1 } from "./systems/pf1.js";
-import { StealthyPF2e } from "./systems/pf2e.js";
 
-Hooks.once('init', () => {
-  const engines = {
-    'dnd5e': () => new Stealthy5e(),
-    'pf1': () => new StealthyPF1(),
-    'pf2e': () => new StealthyPF2e(),
-  }
-  const systemEngine = engines[game.system.id];
+Hooks.once('setup', () => {
+  const systemEngine = Stealthy.engines[game.system.id];
   if (systemEngine) {
-    Stealthy.engine = systemEngine();
+    window.game.stealthy = new Stealthy(systemEngine);
   }
   else {
     console.error(`Stealthy doesn't yet support system id '${game.system.id}'`);
@@ -22,40 +14,34 @@ Hooks.on('renderTokenHUD', (tokenHUD, html, app) => {
   if (game.user.isGM == true) {
     const token = tokenHUD.object;
     const actor = token?.actor;
-    const system = Stealthy.engine;
+    const engine = game.stealthy.engine;
 
     const hidden = actor?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden-label") && !e.disabled);
     if (hidden) {
-      let { flag, value } = system.getHiddenFlagAndValue(hidden);
+      let { flag, value } = engine.getHiddenFlagAndValue(hidden);
       const inputBox = $(
         `<input id="ste_hid_inp_box" title="${game.i18n.localize("stealthy-hidden-inputBox-title")}" type="text" name="hidden_value_inp_box" value="${value}"></input>`
       );
       html.find(".right").append(inputBox);
       inputBox.change(async (inputbox) => {
         if (token === undefined) return;
-        await system.setHiddenValue(actor, duplicate(hidden), flag, Number(inputbox.target.value));
+        await engine.setHiddenValue(actor, duplicate(hidden), flag, Number(inputbox.target.value));
       });
     }
 
     const spot = actor?.effects.find(e => e.label === game.i18n.localize("stealthy-spot-label") && !e.disabled);
     if (spot) {
-      let { flag, value } = system.getSpotFlagAndValue(spot);
+      let { flag, value } = engine.getSpotFlagAndValue(spot);
       const inputBox = $(
         `<input id="ste_spt_inp_box" title="${game.i18n.localize("stealthy-spot-inputBox-title")}" type="text" name="spot_value_inp_box" value="${value}"></input>`
       );
       html.find(".left").append(inputBox);
       inputBox.change(async (inputbox) => {
         if (token === undefined) return;
-        await system.setSpotValue(actor, duplicate(spot), flag, Number(inputbox.target.value));
+        await engine.setSpotValue(actor, duplicate(spot), flag, Number(inputbox.target.value));
       });
     }
   }
-});
-
-Hooks.once('socketlib.ready', () => {
-  Stealthy.socket = socketlib.registerModule('stealthy');
-  Stealthy.socket.register('toggleSpotting', Stealthy.toggleSpotting);
-  Stealthy.socket.register('getSpotting', Stealthy.getSpotting);
 });
 
 Hooks.on('getSceneControlButtons', (controls) => {
@@ -66,12 +52,12 @@ Hooks.on('getSceneControlButtons', (controls) => {
     name: 'stealthy-spotting',
     title: game.i18n.localize("stealthy-active-spot"),
     toggle: true,
-    active: Stealthy.enableSpot,
-    onClick: (toggled) => Stealthy.socket.executeForEveryone('toggleSpotting', toggled)
+    active: game.stealthy.activeSpot,
+    onClick: (toggled) => game.stealthy.socket.executeForEveryone('ToggleActiveSpot', toggled)
   });
 });
 
 Hooks.once('ready', async () => {
   if (!game.user.isGM)
-    Stealthy.enableSpot = await Stealthy.socket.executeAsGM('getSpotting');
+    game.stealthy.activeSpot = await game.stealthy.socket.executeAsGM('GetActiveSpot');
 });

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -1,0 +1,87 @@
+import { Stealthy } from "./stealthy.js";
+
+Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
+  if (skill === 'ste') {
+    await Stealthy.rollStealth(actor, roll);
+  }
+  else if (skill === 'prc') {
+    await Stealthy.rollPerception(actor, roll);
+  }
+});
+
+Hooks.on('renderTokenHUD', (tokenHUD, html, app) => {
+  if (game.user.isGM == true) {
+    const token = tokenHUD.object;
+    const actor = token?.actor;
+
+    const hidden = actor?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden-label") && !e.disabled);
+    if (hidden) {
+      const value = hidden.flags.stealthy?.hidden ?? actor.system.skills.ste.passive;
+      const inputBox = $(
+        `<input id="ste_hid_inp_box" title="${game.i18n.localize("stealthy-hidden-inputBox-title")}" type="text" name="hidden_value_inp_box" value="${value}"></input>`
+      );
+      html.find(".right").append(inputBox);
+      inputBox.change(async (inputbox) => {
+        if (token === undefined) return;
+        let activeHide = duplicate(hidden);
+        activeHide.flags.stealthy = { hidden: Number(inputbox.target.value) };
+        await actor.updateEmbeddedDocuments('ActiveEffect', [activeHide]);
+      });
+    }
+
+    const spot = actor?.effects.find(e => e.label === game.i18n.localize("stealthy-spot-label") && !e.disabled);
+    if (spot) {
+      let normal;
+      let disadv;
+      const active = spot.flags.stealthy?.spot?.normal ?? spot.flags.stealthy?.spot;
+      if (active !== undefined) {
+        normal = active;
+        disadv = spot.flags.stealthy?.spot?.disadvantaged ?? normal - 5;
+      }
+      else {
+        normal = actor.system.skills.prc.passive;
+        disadv = Stealthy.getPassivePerceptionWithDisadvantage(actor);
+      }
+      const inputBox = $(
+        `<input id="ste_spt_inp_box" title="${game.i18n.localize("stealthy-spot-inputBox-title")}" type="text" name="spot_value_inp_box" value="${normal}"></input>`
+      );
+      html.find(".left").append(inputBox);
+      inputBox.change(async (inputbox) => {
+        if (token === undefined) return;
+        let activeSpot = duplicate(spot);
+        const delta = Number(inputbox.target.value) - normal;
+        activeSpot.flags.stealthy = {
+          spot: {
+            normal: normal + delta,
+            disadvantaged: disadv + delta
+          }
+        };
+        await actor.updateEmbeddedDocuments('ActiveEffect', [activeSpot]);
+      });
+    }
+  }
+});
+
+Hooks.once('socketlib.ready', () => {
+  Stealthy.socket = socketlib.registerModule('stealthy');
+  Stealthy.socket.register('toggleSpotting', Stealthy.toggleSpotting);
+  Stealthy.socket.register('getSpotting', Stealthy.getSpotting);
+});
+
+Hooks.on('getSceneControlButtons', (controls) => {
+  if (!game.user.isGM) return;
+  let tokenControls = controls.find(x => x.name === 'token');
+  tokenControls.tools.push({
+    icon: 'fa-solid fa-eyes',
+    name: 'stealthy-spotting',
+    title: game.i18n.localize("stealthy-active-spot"),
+    toggle: true,
+    active: Stealthy.enableSpot,
+    onClick: (toggled) => Stealthy.socket.executeForEveryone('toggleSpotting', toggled)
+  });
+});
+
+Hooks.once('ready', async () => {
+  if (!game.user.isGM)
+    Stealthy.enableSpot = await Stealthy.socket.executeAsGM('getSpotting');
+});

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -1,11 +1,20 @@
 import { Stealthy } from "./stealthy.js";
+import { Stealthy5e } from "./systems/dnd5e.js";
+import { StealthyPF1 } from "./systems/pf1.js";
+import { StealthyPF2e } from "./systems/pf2e.js";
 
-Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
-  if (skill === 'ste') {
-    await Stealthy.rollStealth(actor, roll);
+Hooks.once('init', () => {
+  const engines = {
+    'dnd5e': () => { Stealthy.engine = new Stealthy5e(); },
+    'pf1': () => { Stealthy.engine = new StealthyPF1(); },
+    'pf2e': () => { Stealthy.engine = new StealthyPF2e(); },
   }
-  else if (skill === 'prc') {
-    await Stealthy.rollPerception(actor, roll);
+  const engine = engines[game.system.id];
+  if (engine) {
+    engine();
+  }
+  else {
+    console.error(`Stealthy doesn't yet support system id '${game.system.id}'`);
   }
 });
 
@@ -13,50 +22,31 @@ Hooks.on('renderTokenHUD', (tokenHUD, html, app) => {
   if (game.user.isGM == true) {
     const token = tokenHUD.object;
     const actor = token?.actor;
+    const system = Stealthy.engine;
 
     const hidden = actor?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden-label") && !e.disabled);
     if (hidden) {
-      const value = hidden.flags.stealthy?.hidden ?? actor.system.skills.ste.passive;
+      let { flag, value } = system.getHiddenFlagAndValue(hidden);
       const inputBox = $(
         `<input id="ste_hid_inp_box" title="${game.i18n.localize("stealthy-hidden-inputBox-title")}" type="text" name="hidden_value_inp_box" value="${value}"></input>`
       );
       html.find(".right").append(inputBox);
       inputBox.change(async (inputbox) => {
         if (token === undefined) return;
-        let activeHide = duplicate(hidden);
-        activeHide.flags.stealthy = { hidden: Number(inputbox.target.value) };
-        await actor.updateEmbeddedDocuments('ActiveEffect', [activeHide]);
+        await system.setHiddenValue(actor, duplicate(hidden), flag, Number(inputbox.target.value));
       });
     }
 
     const spot = actor?.effects.find(e => e.label === game.i18n.localize("stealthy-spot-label") && !e.disabled);
     if (spot) {
-      let normal;
-      let disadv;
-      const active = spot.flags.stealthy?.spot?.normal ?? spot.flags.stealthy?.spot;
-      if (active !== undefined) {
-        normal = active;
-        disadv = spot.flags.stealthy?.spot?.disadvantaged ?? normal - 5;
-      }
-      else {
-        normal = actor.system.skills.prc.passive;
-        disadv = Stealthy.getPassivePerceptionWithDisadvantage(actor);
-      }
+      let { flag, value } = system.getSpotFlagAndValue(spot);
       const inputBox = $(
-        `<input id="ste_spt_inp_box" title="${game.i18n.localize("stealthy-spot-inputBox-title")}" type="text" name="spot_value_inp_box" value="${normal}"></input>`
+        `<input id="ste_spt_inp_box" title="${game.i18n.localize("stealthy-spot-inputBox-title")}" type="text" name="spot_value_inp_box" value="${value}"></input>`
       );
       html.find(".left").append(inputBox);
       inputBox.change(async (inputbox) => {
         if (token === undefined) return;
-        let activeSpot = duplicate(spot);
-        const delta = Number(inputbox.target.value) - normal;
-        activeSpot.flags.stealthy = {
-          spot: {
-            normal: normal + delta,
-            disadvantaged: disadv + delta
-          }
-        };
-        await actor.updateEmbeddedDocuments('ActiveEffect', [activeSpot]);
+        await system.setSpotValue(actor, duplicate(spot), flag, Number(inputbox.target.value));
       });
     }
   }

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -5,13 +5,13 @@ import { StealthyPF2e } from "./systems/pf2e.js";
 
 Hooks.once('init', () => {
   const engines = {
-    'dnd5e': () => { Stealthy.engine = new Stealthy5e(); },
-    'pf1': () => { Stealthy.engine = new StealthyPF1(); },
-    'pf2e': () => { Stealthy.engine = new StealthyPF2e(); },
+    'dnd5e': () => new Stealthy5e(),
+    'pf1': () => new StealthyPF1(),
+    'pf2e': () => new StealthyPF2e(),
   }
-  const engine = engines[game.system.id];
-  if (engine) {
-    engine();
+  const systemEngine = engines[game.system.id];
+  if (systemEngine) {
+    Stealthy.engine = systemEngine();
   }
   else {
     console.error(`Stealthy doesn't yet support system id '${game.system.id}'`);

--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -5,9 +5,9 @@ Hooks.once('setup', () => {
     'stealthy',
     'DetectionModeBasicSight.prototype.testVisibility',
     (wrapped, visionSource, mode, config = {}) => {
-      const system = Stealthy.engine;
-      if (!system.testStealth(visionSource, config)) return false;
-      return system.basicVision(wrapped, visionSource, mode, config);
+      const engine = game.stealthy.engine;
+      if (!engine.testStealth(visionSource, config)) return false;
+      return engine.basicVision(wrapped, visionSource, mode, config);
     },
     libWrapper.MIXED,
     { perf_mode: libWrapper.PERF_FAST }
@@ -17,9 +17,9 @@ Hooks.once('setup', () => {
     'stealthy',
     'DetectionModeInvisibility.prototype.testVisibility',
     (wrapped, visionSource, mode, config = {}) => {
-      const system = Stealthy.engine;
-      if (!system.testStealth(visionSource, config)) return false;
-      return system.seeInvisibility(wrapped, visionSource, mode, config);
+      const engine = game.stealthy.engine;
+      if (!engine.testStealth(visionSource, config)) return false;
+      return engine.seeInvisibility(wrapped, visionSource, mode, config);
     },
     libWrapper.MIXED,
     { perf_mode: libWrapper.PERF_FAST }

--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -5,26 +5,9 @@ Hooks.once('setup', () => {
     'stealthy',
     'DetectionModeBasicSight.prototype.testVisibility',
     (wrapped, visionSource, mode, config = {}) => {
-      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
-
-      const target = config.object?.actor;
-      let noDarkvision = false;
-      const ignoreFriendlyUmbralSight =
-        game.settings.get('stealthy', 'ignoreFriendlyUmbralSight') &&
-        config.object.document?.disposition === visionSource.object.document?.disposition;
-      if (!ignoreFriendlyUmbralSight && visionSource.visionMode?.id === 'darkvision') {
-        const umbralSight = target?.itemTypes?.feat?.find(f => f.name === game.i18n.localize('Umbral Sight'));
-        if (umbralSight) noDarkvision = true;
-      }
-
-      if (noDarkvision) {
-        Stealthy.log(`${visionSource.object.name}'s darkvision can't see ${config.object.name}`);
-        let ourMode = duplicate(mode);
-        ourMode.range = 0;
-        return wrapped(visionSource, ourMode, config);
-      }
-
-      return wrapped(visionSource, mode, config);
+      const system = Stealthy.engine;
+      if (!system.testStealth(visionSource, config)) return false;
+      return system.basicVision(wrapped, visionSource, mode, config);
     },
     libWrapper.MIXED,
     { perf_mode: libWrapper.PERF_FAST }
@@ -34,8 +17,9 @@ Hooks.once('setup', () => {
     'stealthy',
     'DetectionModeInvisibility.prototype.testVisibility',
     (wrapped, visionSource, mode, config = {}) => {
-      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
-      return wrapped(visionSource, mode, config);
+      const system = Stealthy.engine;
+      if (!system.testStealth(visionSource, config)) return false;
+      return system.seeInvisibility(wrapped, visionSource, mode, config);
     },
     libWrapper.MIXED,
     { perf_mode: libWrapper.PERF_FAST }

--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -1,0 +1,43 @@
+import { Stealthy } from "./stealthy.js";
+
+Hooks.once('setup', () => {
+  libWrapper.register(
+    'stealthy',
+    'DetectionModeBasicSight.prototype.testVisibility',
+    (wrapped, visionSource, mode, config = {}) => {
+      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
+
+      const target = config.object?.actor;
+      let noDarkvision = false;
+      const ignoreFriendlyUmbralSight =
+        game.settings.get('stealthy', 'ignoreFriendlyUmbralSight') &&
+        config.object.document?.disposition === visionSource.object.document?.disposition;
+      if (!ignoreFriendlyUmbralSight && visionSource.visionMode?.id === 'darkvision') {
+        const umbralSight = target?.itemTypes?.feat?.find(f => f.name === game.i18n.localize('Umbral Sight'));
+        if (umbralSight) noDarkvision = true;
+      }
+
+      if (noDarkvision) {
+        Stealthy.log(`${visionSource.object.name}'s darkvision can't see ${config.object.name}`);
+        let ourMode = duplicate(mode);
+        ourMode.range = 0;
+        return wrapped(visionSource, ourMode, config);
+      }
+
+      return wrapped(visionSource, mode, config);
+    },
+    libWrapper.MIXED,
+    { perf_mode: libWrapper.PERF_FAST }
+  );
+
+  libWrapper.register(
+    'stealthy',
+    'DetectionModeInvisibility.prototype.testVisibility',
+    (wrapped, visionSource, mode, config = {}) => {
+      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
+      return wrapped(visionSource, mode, config);
+    },
+    libWrapper.MIXED,
+    { perf_mode: libWrapper.PERF_FAST }
+  );
+});

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -108,6 +108,12 @@ export class Stealthy {
   static CONSOLE_COLORS = ['background: #222; color: #80ffff', 'color: #fff'];
   static engines = {};
 
+  static RegisterEngine(id, makeEngine) {
+    if (id !== game.system.id) return;
+    console.log(`stealthy | Registering Stealth engine for '${id}'`);
+    Stealthy.engines[id] = makeEngine;
+  }
+
   static log(format, ...args) {
     const level = game.settings.get('stealthy', 'logLevel');
     if (level !== 'none') {

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -76,6 +76,7 @@ export class Stealthy {
 
   static async rollPerception(actor, roll) {
     if (!Stealthy.enableSpot) return;
+    Stealthy.log('rollPerception', { actor, roll });
     const label = game.i18n.localize("stealthy-spot-label");
     let spot = actor.effects.find(e => e.label === label);
 
@@ -115,6 +116,7 @@ export class Stealthy {
   }
 
   static async rollStealth(actor, roll) {
+    Stealthy.log('rollStealth', { actor, roll });
     const label = game.i18n.localize("stealthy-hidden-label");
     let hidden = actor.effects.find(e => e.label === label);
 

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -46,7 +46,7 @@ export class StealthyBaseEngine {
     return wrapped(visionSource, mode, config);
   }
 
-  async UpdateOrCreateEffect({ label, actor, flag, makeEffect }) {
+  async updateOrCreateEffect({ label, actor, flag, makeEffect }) {
     let effect = actor.effects.find(e => e.label === label);
 
     if (!effect) {

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -1,8 +1,11 @@
 export class Stealthy {
 
   static CONSOLE_COLORS = ['background: #222; color: #80ffff', 'color: #fff'];
-  static lightNumTable = ['dark', 'dim', 'bright'];
+  static LIGHT_LABELS = ['dark', 'dim', 'bright'];
   static socket;
+  static enableSpot = true;
+
+  //########### Logging Functions ##############
 
   static log(format, ...args) {
     const level = game.settings.get('stealthy', 'logLevel');
@@ -24,176 +27,7 @@ export class Stealthy {
     }
   }
 
-  // check target Token Lighting conditions via effects usage
-  // look for effects that indicate Dim or Dark condition on the token
-  static tokenLighting5e(spot, perception, visionSource, source, target) {
-    let lightLevel = 2;
-    let debugData = { perception };
-
-    if (target?.effects.find(e => e.label === game.i18n.localize("stealthy-dark-label") && !e.disabled)) { lightLevel = 0; }
-    if (target?.effects.find(e => e.label === game.i18n.localize("stealthy-dim-label") && !e.disabled)) { lightLevel = 1; }
-    debugData.lightLevel = Stealthy.lightNumTable[lightLevel];
-
-    // check if Darkvision is in use, bump light level accordingly
-    if (visionSource.visionMode?.id === 'darkvision') {
-      lightLevel = lightLevel + 1;
-      debugData.darklightLevel = Stealthy.lightNumTable[lightLevel];
-    }
-
-    // adjust passive perception depending on light conditions of target token
-    // don't adjust for active perception checks via 'spot' flag usage
-    if (lightLevel < 2 && !spot?.flags.stealthy?.spot) {
-      perception = perception - 5;
-      debugData.disadvantagedPassive = perception;
-    };
-
-    Stealthy.log('tokenLighting5e', debugData);
-    return perception;
-  }
-
-  static isHidden5e(visionSource, hidden, target, config) {
-    const source = visionSource.object?.actor;
-    const stealth = hidden.flags.stealthy?.hidden ?? target.system.skills.ste.passive;
-    const spot = source?.effects.find(e => e.label === game.i18n.localize("stealthy-spot-label") && !e.disabled);
-
-    // active perception loses ties, passive perception wins ties to simulate the
-    // idea that active skills need to win outright to change the status quo. Passive
-    // perception means that stealth is being the active skill.
-    let perception = spot?.flags.stealthy?.spot ?? (source.system.skills.prc.passive + 1);
-
-    if (game.settings.get('stealthy', 'tokenLighting')) {
-      perception = Stealthy.tokenLighting5e(spot, perception, visionSource, source, target);
-    }
-
-    if (perception <= stealth) {
-      Stealthy.log(`${visionSource.object.name}'s ${perception} can't see ${config.object.name}'s ${stealth}`);
-      return true;
-    }
-    return false;
-  }
-
-  static enableSpot = true;
-
-  static async rollPerception(actor, roll) {
-    if (!Stealthy.enableSpot) return;
-    Stealthy.log('rollPerception', { actor, roll });
-    const label = game.i18n.localize("stealthy-spot-label");
-    let spot = actor.effects.find(e => e.label === label);
-    let flag = { spot: Math.max(roll.total, actor.system.skills.prc.passive) };
-
-    if (!spot) {
-      // See if we can source from outside
-      const source = game.settings.get('stealthy', 'hiddenSource');
-      if (source === 'ce') {
-        await game.dfreds.effectInterface.addEffect({ effectName: label, uuid: actor.uuid });
-        spot = actor.effects.find(e => e.label === label);
-      }
-      else if (source === 'cub') {
-        await game.cub.applyCondition(label, actor);
-        spot = actor.effects.find(e => e.label === label);
-      }
-
-      // If we haven't found an ouside source, create the default one
-      if (!spot) {
-        spot = {
-          label,
-          icon: 'icons/commodities/biological/eye-blue.webp',
-          duration: { turns: 1, seconds: 6 },
-          flags: {
-            convenientDescription: game.i18n.localize("stealthy-spot-description"),
-            stealthy: flag,
-          },
-        };
-
-        await actor.createEmbeddedDocuments('ActiveEffect', [spot]);
-        return;
-      }
-    }
-    
-    let activeSpot = duplicate(spot);
-    activeSpot.flags.stealthy = flag;
-    activeSpot.disabled = false;
-    await actor.updateEmbeddedDocuments('ActiveEffect', [activeSpot]);
-  }
-
-  static async rollStealth(actor, roll) {
-    Stealthy.log('rollStealth', { actor, roll });
-    const label = game.i18n.localize("stealthy-hidden-label");
-    let hidden = actor.effects.find(e => e.label === label);
-    let flag = { hidden: roll.total };
-
-    if (!hidden) {
-      // See if we can source from outside
-      const source = game.settings.get('stealthy', 'hiddenSource');
-      if (source === 'ce') {
-        await game.dfreds.effectInterface.addEffect({ effectName: label, uuid: actor.uuid });
-        hidden = actor.effects.find(e => e.label === label);
-      }
-      else if (source === 'cub') {
-        await game.cub.applyCondition(label, actor);
-        hidden = actor.effects.find(e => e.label === label);
-      }
-
-      // If we haven't found an ouside source, create the default one
-      if (!hidden) {
-        hidden = {
-          label,
-          icon: 'icons/magic/perception/shadow-stealth-eyes-purple.webp',
-          changes: [],
-          flags: {
-            core: {statusId: '1'},
-            convenientDescription: game.i18n.localize("stealthy-hidden-description"),
-            stealthy: flag
-          },
-        };
-
-        if (source === 'ae') {
-          if (typeof TokenMagic !== 'undefined') {
-            hidden.changes.push({
-              key: 'macro.tokenMagic',
-              mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
-              value: 'fog'
-            });
-          }
-          else if (typeof ATLUpdate !== 'undefined') {
-            hidden.changes.push({
-              key: 'ATL.alpha',
-              mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
-              value: '0.5'
-            });
-          }
-        }
-
-        // No need to update the effect with roll data because we just created it therein
-        await actor.createEmbeddedDocuments('ActiveEffect', [hidden]);
-        return;
-      }
-    }
-
-    // Need to stick the roll data into a flag and update the effect
-    let activeHide = duplicate(hidden);
-    activeHide.flags.stealthy = flag;
-    activeHide.disabled = false;
-    await actor.updateEmbeddedDocuments('ActiveEffect', [activeHide]);
-  }
-
-  static testVisionStealth(visionSource, config) {
-    const target = config.object?.actor;
-    const ignoreFriendlyStealth =
-      game.settings.get('stealthy', 'ignoreFriendlyStealth') &&
-      config.object.document?.disposition === visionSource.object.document?.disposition;
-
-    if (!ignoreFriendlyStealth) {
-      const hidden = target?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden-label") && !e.disabled);
-      if (hidden) {
-        // This will be better implemented as an interface
-        // First thing to do when adding second supported system
-        if (Stealthy.isHidden5e(visionSource, hidden, target, config)) return false;
-      }
-    }
-
-    return true;
-  }
+  //########### Socket Functions ##############
 
   static async toggleSpotting(toggled) {
     Stealthy.enableSpot = toggled;
@@ -214,122 +48,233 @@ export class Stealthy {
     return Stealthy.enableSpot;
   }
 
+  //###################### Vision Tests ################
+
+  static testVisionStealth(visionSource, config) {
+    const target = config.object?.actor;
+    const ignoreFriendlyStealth =
+      game.settings.get('stealthy', 'ignoreFriendlyStealth') &&
+      config.object.document?.disposition === visionSource.object.document?.disposition;
+
+    if (!ignoreFriendlyStealth) {
+      const hidden = target?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden-label") && !e.disabled);
+      if (hidden) {
+        // This will be better implemented as an interface
+        // First thing to do when adding second supported system
+        if (Stealthy.isHidden5e(visionSource, hidden, target, config)) return false;
+      }
+    }
+
+    return true;
+  }
+
+  static isHidden5e(visionSource, hidden, target, config) {
+    const source = visionSource.object?.actor;
+    const stealth = hidden.flags.stealthy?.hidden ?? target.system.skills.ste.passive;
+    const spot = source?.effects.find(e => e.label === game.i18n.localize("stealthy-spot-label") && !e.disabled);
+
+    // active perception loses ties, passive perception wins ties to simulate the
+    // idea that active skills need to win outright to change the status quo. Passive
+    // perception means that stealth is being the active skill.
+    const spotPair = spot?.flags.stealthy?.spot;
+    let perception;
+
+    if (game.settings.get('stealthy', 'tokenLighting')) {
+      perception = Stealthy.adjustForLightingConditions5e(spotPair, visionSource, source, target);
+    }
+    else {
+      perception = Stealthy.adjustForConditions5e(spotPair, visionSource, source, target);
+    }
+
+    if (perception <= stealth) {
+      Stealthy.log(`${visionSource.object.name}'s ${perception} can't see ${config.object.name}'s ${stealth}`);
+      return true;
+    }
+    return false;
+  }
+
+  static adjustForConditions5e(spotPair, visionSource, source, target) {
+    let perception = spotPair?.normal
+      ?? spotPair
+      ?? (source.system.skills.prc.passive + 1);
+    perception = Math.max(perception, source.system.skills.prc.passive);
+    return perception;
+  }
+
+  //########################## Skills #####################################
+
+  static async rollPerception(actor, roll) {
+    if (!Stealthy.enableSpot) return;
+    Stealthy.log('rollPerception', { actor, roll });
+
+    let perception = { normal: roll.total, disadvantaged: roll.total };
+    if (!roll.hasDisadvantage && game.settings.get('stealthy', 'spotPair')) {
+      const dice = roll.dice[0];
+      if (roll.hasAdvantage) {
+        const delta = dice.results[1].result - dice.results[0].result;
+        if (delta > 0) {
+          perception.disadvantaged -= delta;
+        }
+      }
+      else {
+        let disadvantageRoll = await new Roll(`1d20`).evaluate();
+        game.dice3d?.showForRoll(disadvantageRoll);
+        const delta = dice.results[0].result - disadvantageRoll.total;
+        if (delta > 0) {
+          perception.disadvantaged -= delta;
+        }
+      }
+      Stealthy.log('perception', perception);
+    }
+
+    const label = game.i18n.localize("stealthy-spot-label");
+    await Stealthy.updateOrCreateEffect({
+      label,
+      actor,
+      flag: { spot: perception },
+      makeEffect: (flag, source) => ({
+        label,
+        icon: 'icons/commodities/biological/eye-blue.webp',
+        duration: { turns: 1, seconds: 6 },
+        flags: {
+          convenientDescription: game.i18n.localize("stealthy-spot-description"),
+          stealthy: flag
+        },
+      })
+    });
+  }
+
+  static async rollStealth(actor, roll) {
+    Stealthy.log('rollStealth', { actor, roll });
+
+    const label = game.i18n.localize("stealthy-hidden-label");
+    await Stealthy.updateOrCreateEffect({
+      label,
+      actor,
+      flag: { hidden: roll.total },
+      makeEffect: (flag, source) => {
+        let hidden = {
+          label,
+          icon: 'icons/magic/perception/shadow-stealth-eyes-purple.webp',
+          changes: [],
+          flags: {
+            convenientDescription: game.i18n.localize("stealthy-hidden-description"),
+            stealthy: flag,
+            core: { statusId: '1' },
+          },
+        };
+        if (source === 'ae') {
+          if (typeof TokenMagic !== 'undefined') {
+            hidden.changes.push({
+              key: 'macro.tokenMagic',
+              mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+              value: 'fog'
+            });
+          }
+          else if (typeof ATLUpdate !== 'undefined') {
+            hidden.changes.push({
+              key: 'ATL.alpha',
+              mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+              value: '0.5'
+            });
+          }
+        }
+        return hidden;
+      }
+    });
+  }
+
+  static getPassivePerceptionWithDisadvantage(source) {
+    // todo: don't apply -5 if already disadvantaged
+    return source.system.skills.prc.passive - 5;
+  }
+
+  static async updateOrCreateEffect({ label, actor, flag, makeEffect }) {
+    let effect = actor.effects.find(e => e.label === label);
+
+    if (!effect) {
+      // See if we can source from outside
+      const source = game.settings.get('stealthy', 'hiddenSource');
+      if (source === 'ce') {
+        await game.dfreds.effectInterface.addEffect({ effectName: label, uuid: actor.uuid });
+        effect = actor.effects.find(e => e.label === label);
+      }
+      else if (source === 'cub') {
+        await game.cub.applyCondition(label, actor);
+        effect = actor.effects.find(e => e.label === label);
+      }
+
+      // If we haven't found an ouside source, create the default one
+      if (!effect) {
+        effect = makeEffect(flag, source);
+        await actor.createEmbeddedDocuments('ActiveEffect', [effect]);
+        return;
+      }
+    }
+
+    effect = duplicate(effect);
+    effect.flags.stealthy = flag;
+    effect.disabled = false;
+    await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
+  }
+
+  //#################### Support for Token lighting ##################
+  
+  // check target Token Lighting conditions via effects usage
+  // look for effects that indicate Dim or Dark condition on the token
+  static adjustForLightingConditions5e(spotPair, visionSource, source, target) {
+    let debugData = { spotPair };
+    let perception;
+
+    // What light band are we told we sit in?
+    let lightBand = 2;
+    if (target?.effects.find(e => e.label === game.i18n.localize("stealthy-dark-label") && !e.disabled)) { lightBand = 0; }
+    if (target?.effects.find(e => e.label === game.i18n.localize("stealthy-dim-label") && !e.disabled)) { lightBand = 1; }
+    debugData.lightLevel = Stealthy.LIGHT_LABELS[lightBand];
+
+    // Adjust the light band based on conditions
+    if (visionSource.visionMode?.id === 'darkvision') {
+      lightBand = lightBand + 1;
+      debugData.foundryDarkvision = Stealthy.LIGHT_LABELS[lightBand];
+    }
+
+    // Extract the normal perception values from the source
+    let active = spotPair?.normal ?? spotPair;
+    let value;
+    if (active !== undefined) {
+      value = active;
+      debugData.active = value;
+    }
+    else {
+      value = source.system.skills.prc.passive;
+      debugData.passive = value;
+    }
+
+    // dark = fail, dim = disadvantage, bright = normal
+    if (lightBand <= 0) {
+      perception = -100;
+      debugData.cantSee = perception;
+    }
+    else if (lightBand === 1) {
+      let passiveDisadv = Stealthy.getPassivePerceptionWithDisadvantage(source);
+      if (active !== undefined) {
+        value = spotPair?.disadvantaged ?? value - 5;
+        debugData.activeDisadv = value;
+      }
+      else {
+        value = passiveDisadv;
+        debugData.passiveDisadv = value;
+      }
+      perception = Math.max(value, passiveDisadv);
+      debugData.seesDim = perception;
+    }
+    else {
+      perception = Math.max(value, source.system.skills.prc.passive);
+      debugData.seesBright = perception;
+    }
+
+    Stealthy.log('adjustForLightingConditions5e', debugData);
+    return perception;
+  }
+
 }
-
-Hooks.once('setup', () => {
-  libWrapper.register(
-    'stealthy',
-    'DetectionModeBasicSight.prototype.testVisibility',
-    (wrapped, visionSource, mode, config = {}) => {
-      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
-
-      const target = config.object?.actor;
-      let noDarkvision = false;
-      const ignoreFriendlyUmbralSight =
-        game.settings.get('stealthy', 'ignoreFriendlyUmbralSight') &&
-        config.object.document?.disposition === visionSource.object.document?.disposition;
-      if (!ignoreFriendlyUmbralSight && visionSource.visionMode?.id === 'darkvision') {
-        const umbralSight = target?.itemTypes?.feat?.find(f => f.name === game.i18n.localize('Umbral Sight'));
-        if (umbralSight) noDarkvision = true;
-      }
-
-      if (noDarkvision) {
-        Stealthy.log(`${visionSource.object.name}'s darkvision can't see ${config.object.name}`);
-        let ourMode = duplicate(mode);
-        ourMode.range = 0;
-        return wrapped(visionSource, ourMode, config);
-      }
-
-      return wrapped(visionSource, mode, config);
-    },
-    libWrapper.MIXED,
-    { perf_mode: libWrapper.PERF_FAST }
-  );
-
-  libWrapper.register(
-    'stealthy',
-    'DetectionModeInvisibility.prototype.testVisibility',
-    (wrapped, visionSource, mode, config = {}) => {
-      if (!Stealthy.testVisionStealth(visionSource, config)) return false;
-      return wrapped(visionSource, mode, config);
-    },
-    libWrapper.MIXED,
-    { perf_mode: libWrapper.PERF_FAST }
-  );
-});
-
-Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
-  if (skill === 'ste') {
-    await Stealthy.rollStealth(actor, roll);
-  }
-  else if (skill === 'prc') {
-    await Stealthy.rollPerception(actor, roll);
-  }
-});
-
-Hooks.on('renderTokenHUD', (tokenHUD, html, app) => {
-  if (game.user.isGM == true) {
-    const token = tokenHUD.object;
-    const actor = token?.actor;
-
-    const hidden = actor?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden-label") && !e.disabled);
-    if (hidden) {
-      const value = hidden.flags.stealthy?.hidden ?? actor.system.skills.ste.passive;
-      const inputBox = $(
-        `<input id="ste_hid_inp_box" title="${game.i18n.localize("stealthy-hidden-inputBox-title")}" type="text" name="hidden_value_inp_box" value="${value}"></input>`
-      );
-      html.find(".right").append(inputBox);
-      inputBox.change(async (inputbox) => {
-        if (token === undefined) return;
-        let activeHide = duplicate(hidden);
-        activeHide.flags.stealthy = { hidden: Number(inputbox.target.value) };
-        await actor.updateEmbeddedDocuments('ActiveEffect', [activeHide]);
-      });
-    }
-
-    const spot = actor?.effects.find(e => e.label === game.i18n.localize("stealthy-spot-label") && !e.disabled);
-    if (spot) {
-      const value = spot.flags.stealthy?.spot ?? actor.system.skills.prc.passive;
-      const inputBox = $(
-        `<input id="ste_spt_inp_box" title="${game.i18n.localize("stealthy-spot-inputBox-title")}" type="text" name="spot_value_inp_box" value="${value}"></input>`
-      );
-      html.find(".left").append(inputBox);
-      inputBox.change(async (inputbox) => {
-        if (token === undefined) return;
-        let activeSpot = duplicate(spot);
-        activeSpot.flags.stealthy = { spot: Number(inputbox.target.value) };
-        await actor.updateEmbeddedDocuments('ActiveEffect', [activeSpot]);
-      });
-    }
-  }
-});
-
-Hooks.on('renderSettingsConfig', (app, html, data) => {
-  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-general")).insertBefore($('[name="stealthy.ignoreFriendlyStealth"]').parents('div.form-group:first'));
-  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-debug")).insertBefore($('[name="stealthy.logLevel"]').parents('div.form-group:first'));
-  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy-config-experimental")).insertBefore($('[name="stealthy.tokenLighting"]').parents('div.form-group:first'));
-});
-
-Hooks.once('socketlib.ready', () => {
-  Stealthy.socket = socketlib.registerModule('stealthy');
-  Stealthy.socket.register('toggleSpotting', Stealthy.toggleSpotting);
-  Stealthy.socket.register('getSpotting', Stealthy.getSpotting);
-});
-
-Hooks.on('getSceneControlButtons', (controls) => {
-  if (!game.user.isGM) return;
-  let tokenControls = controls.find(x => x.name === 'token');
-  tokenControls.tools.push({
-    icon: 'fa-solid fa-eyes',
-    name: 'stealthy-spotting',
-    title: game.i18n.localize("stealthy-active-spot"),
-    toggle: true,
-    active: Stealthy.enableSpot,
-    onClick: (toggled) => Stealthy.socket.executeForEveryone('toggleSpotting', toggled)
-  });
-});
-
-Hooks.once('ready', async () => {
-  if (!game.user.isGM)
-    Stealthy.enableSpot = await Stealthy.socket.executeAsGM('getSpotting');
-});

--- a/scripts/stealthy.js
+++ b/scripts/stealthy.js
@@ -46,6 +46,50 @@ export class StealthyBaseEngine {
     return wrapped(visionSource, mode, config);
   }
 
+  makeHiddenEffect(label) {
+    return (flag, source) => {
+      let hidden = {
+        label,
+        icon: 'icons/magic/perception/shadow-stealth-eyes-purple.webp',
+        changes: [],
+        flags: {
+          convenientDescription: game.i18n.localize("stealthy-hidden-description"),
+          stealthy: flag,
+          core: { statusId: '1' },
+        },
+      };
+      if (source === 'ae') {
+        if (typeof TokenMagic !== 'undefined') {
+          hidden.changes.push({
+            key: 'macro.tokenMagic',
+            mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+            value: 'fog'
+          });
+        }
+        else if (typeof ATLUpdate !== 'undefined') {
+          hidden.changes.push({
+            key: 'ATL.alpha',
+            mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+            value: '0.5'
+          });
+        }
+      }
+      return hidden;
+    };
+  }
+
+  makeSpotEffect(label) {
+    return (flag, source) => ({
+      label,
+      icon: 'icons/commodities/biological/eye-blue.webp',
+      duration: { turns: 1, seconds: 6 },
+      flags: {
+        convenientDescription: game.i18n.localize("stealthy-spot-description"),
+        stealthy: flag
+      },
+    });
+  }
+
   async updateOrCreateEffect({ label, actor, flag, makeEffect }) {
     let effect = actor.effects.find(e => e.label === label);
 

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -6,10 +6,10 @@ export class Stealthy5e extends StealthyBaseEngine {
     super();
     Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
       if (skill === 'ste') {
-        await Stealthy5e.rollStealth(actor, roll);
+        await this.rollStealth(actor, roll);
       }
       else if (skill === 'prc') {
-        await Stealthy5e.rollPerception(actor, roll);
+        await this.rollPerception(actor, roll);
       }
     });
   }
@@ -96,9 +96,9 @@ export class Stealthy5e extends StealthyBaseEngine {
     await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
   }
 
-  static async rollPerception(actor, roll) {
+  async rollPerception(actor, roll) {
     if (!game.stealthy.activeSpot) return;
-    Stealthy.log('rollPerception', { actor, roll });
+    Stealthy.log('Stealthy5e.rollPerception', { actor, roll });
 
     let perception = { normal: roll.total, disadvantaged: roll.total };
     if (!roll.hasDisadvantage && game.settings.get('stealthy', 'spotPair')) {
@@ -120,7 +120,7 @@ export class Stealthy5e extends StealthyBaseEngine {
     }
 
     const label = game.i18n.localize("stealthy-spot-label");
-    await Stealthy.UpdateOrCreateEffect({
+    await this.UpdateOrCreateEffect({
       label,
       actor,
       flag: { spot: perception },
@@ -136,11 +136,11 @@ export class Stealthy5e extends StealthyBaseEngine {
     });
   }
 
-  static async rollStealth(actor, roll) {
-    Stealthy.log('rollStealth', { actor, roll });
+  async rollStealth(actor, roll) {
+    Stealthy.log('Stealthy5e.rollStealth', { actor, roll });
 
     const label = game.i18n.localize("stealthy-hidden-label");
-    await Stealthy.UpdateOrCreateEffect({
+    await this.UpdateOrCreateEffect({
       label,
       actor,
       flag: { hidden: roll.total },

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -60,11 +60,7 @@ export class Stealthy5e extends StealthyBaseEngine {
       return wrapped(visionSource, ourMode, config);
     }
 
-    return wrapped(visionSource, mode, config);
-  }
-
-  seeInvisibility(wrapped, visionSource, mode, config) {
-    return wrapped(visionSource, mode, config);
+    return super.basicVision(wrapped, visionSource, mode, config);
   }
 
   static async rollPerception(actor, roll) {

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -1,0 +1,254 @@
+import { Stealthy, StealthyBaseEngine } from '../stealthy.js';
+
+export class Stealthy5e extends StealthyBaseEngine {
+
+  constructor() {
+    super();
+    Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
+      if (skill === 'ste') {
+        await Stealthy5e.rollStealth(actor, roll);
+      }
+      else if (skill === 'prc') {
+        await Stealthy5e.rollPerception(actor, roll);
+      }
+    });
+  }
+
+  static LIGHT_LABELS = ['dark', 'dim', 'bright'];
+
+  isHidden(visionSource, hidden, target, config) {
+    const source = visionSource.object?.actor;
+    const stealth = hidden.flags.stealthy?.hidden ?? target.system.skills.ste.passive;
+    const spot = source?.effects.find(e => e.label === game.i18n.localize("stealthy-spot-label") && !e.disabled);
+
+    // active perception loses ties, passive perception wins ties to simulate the
+    // idea that active skills need to win outright to change the status quo. Passive
+    // perception means that stealth is being the active skill.
+    const spotPair = spot?.flags.stealthy?.spot;
+    let perception;
+
+    if (game.settings.get('stealthy', 'tokenLighting')) {
+      perception = Stealthy5e.AdjustForLightingConditions(spotPair, visionSource, source, target);
+    }
+    else {
+      perception = Stealthy5e.AdjustForDefaultConditions(spotPair, visionSource, source, target);
+    }
+
+    if (perception <= stealth) {
+      Stealthy.log(`${visionSource.object.name}'s ${perception} can't see ${config.object.name}'s ${stealth}`);
+      return true;
+    }
+    return false;
+  }
+
+  basicVision(wrapped, visionSource, mode, config)
+  {
+    const target = config.object?.actor;
+    let noDarkvision = false;
+    const ignoreFriendlyUmbralSight =
+      game.settings.get('stealthy', 'ignoreFriendlyUmbralSight') &&
+      config.object.document?.disposition === visionSource.object.document?.disposition;
+    if (!ignoreFriendlyUmbralSight && visionSource.visionMode?.id === 'darkvision') {
+      const umbralSight = target?.itemTypes?.feat?.find(f => f.name === game.i18n.localize('Umbral Sight'));
+      if (umbralSight) noDarkvision = true;
+    }
+
+    if (noDarkvision) {
+      Stealthy.log(`${visionSource.object.name}'s darkvision can't see ${config.object.name}`);
+      let ourMode = duplicate(mode);
+      ourMode.range = 0;
+      return wrapped(visionSource, ourMode, config);
+    }
+
+    return wrapped(visionSource, mode, config);
+  }
+
+  seeInvisibility(wrapped, visionSource, mode, config) {
+    return wrapped(visionSource, mode, config);
+  }
+
+  static async rollPerception(actor, roll) {
+    if (!Stealthy.enableSpot) return;
+    Stealthy.log('rollPerception', { actor, roll });
+
+    let perception = { normal: roll.total, disadvantaged: roll.total };
+    if (!roll.hasDisadvantage && game.settings.get('stealthy', 'spotPair')) {
+      const dice = roll.dice[0];
+      if (roll.hasAdvantage) {
+        const delta = dice.results[1].result - dice.results[0].result;
+        if (delta > 0) {
+          perception.disadvantaged -= delta;
+        }
+      }
+      else {
+        let disadvantageRoll = await new Roll(`1d20`).evaluate();
+        game.dice3d?.showForRoll(disadvantageRoll);
+        const delta = dice.results[0].result - disadvantageRoll.total;
+        if (delta > 0) {
+          perception.disadvantaged -= delta;
+        }
+      }
+    }
+
+    const label = game.i18n.localize("stealthy-spot-label");
+    await Stealthy.UpdateOrCreateEffect({
+      label,
+      actor,
+      flag: { spot: perception },
+      makeEffect: (flag, source) => ({
+        label,
+        icon: 'icons/commodities/biological/eye-blue.webp',
+        duration: { turns: 1, seconds: 6 },
+        flags: {
+          convenientDescription: game.i18n.localize("stealthy-spot-description"),
+          stealthy: flag
+        },
+      })
+    });
+  }
+
+  static async rollStealth(actor, roll) {
+    Stealthy.log('rollStealth', { actor, roll });
+
+    const label = game.i18n.localize("stealthy-hidden-label");
+    await Stealthy.UpdateOrCreateEffect({
+      label,
+      actor,
+      flag: { hidden: roll.total },
+      makeEffect: (flag, source) => {
+        let hidden = {
+          label,
+          icon: 'icons/magic/perception/shadow-stealth-eyes-purple.webp',
+          changes: [],
+          flags: {
+            convenientDescription: game.i18n.localize("stealthy-hidden-description"),
+            stealthy: flag,
+            core: { statusId: '1' },
+          },
+        };
+        if (source === 'ae') {
+          if (typeof TokenMagic !== 'undefined') {
+            hidden.changes.push({
+              key: 'macro.tokenMagic',
+              mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+              value: 'fog'
+            });
+          }
+          else if (typeof ATLUpdate !== 'undefined') {
+            hidden.changes.push({
+              key: 'ATL.alpha',
+              mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+              value: '0.5'
+            });
+          }
+        }
+        return hidden;
+      }
+    });
+  }
+
+  getHiddenFlagAndValue(hidden) {
+    const value = hidden.flags.stealthy?.hidden ?? actor.system.skills.ste.passive;
+    return { flag: {hidden: value}, value };
+  }
+
+  async setHiddenValue(actor, effect, flag, value) {
+    flag.hidden = value;
+    effect.flags.stealthy = flag;
+    await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
+  }
+
+  getSpotFlagAndValue(spot) {
+    let flag = { normal: undefined, disadvantaged: undefined };
+    const active = spot.flags.stealthy?.spot?.normal ?? spot.flags.stealthy?.spot;
+    if (active !== undefined) {
+      flag.normal = active;
+      flag.disadvantaged = spot.flags.stealthy?.spot?.disadvantaged ?? active - 5;
+    }
+    else {
+      flag.normal = actor.system.skills.prc.passive;
+      disadvantaged = Stealthy5e.GetPassivePerceptionWithDisadvantage(actor);
+    }
+    return { flag: {spot: flag}, value: flag.normal };
+  }
+
+  async setSpotValue(actor, effect, flag, value) {
+    const delta = value - flag.spot.normal;
+    flag.spot.normal = value;
+    flag.spot.disadvantaged += delta;
+    effect.flags.stealthy = flag;
+
+    await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
+  }
+
+  static GetPassivePerceptionWithDisadvantage(source) {
+    // todo: don't apply -5 if already disadvantaged
+    return source.system.skills.prc.passive - 5;
+  }
+  
+  static AdjustForDefaultConditions(spotPair, visionSource, source, target) {
+    let perception = spotPair?.normal
+      ?? spotPair
+      ?? (source.system.skills.prc.passive + 1);
+    perception = Math.max(perception, source.system.skills.prc.passive);
+    return perception;
+  }
+
+  // check target Token Lighting conditions via effects usage
+  // look for effects that indicate Dim or Dark condition on the token
+  static AdjustForLightingConditions(spotPair, visionSource, source, target) {
+    let debugData = { spotPair };
+    let perception;
+
+    // What light band are we told we sit in?
+    let lightBand = 2;
+    if (target?.effects.find(e => e.label === game.i18n.localize("stealthy-dark-label") && !e.disabled)) { lightBand = 0; }
+    if (target?.effects.find(e => e.label === game.i18n.localize("stealthy-dim-label") && !e.disabled)) { lightBand = 1; }
+    debugData.lightLevel = Stealthy5e.LIGHT_LABELS[lightBand];
+
+    // Adjust the light band based on conditions
+    if (visionSource.visionMode?.id === 'darkvision') {
+      lightBand = lightBand + 1;
+      debugData.foundryDarkvision = Stealthy5e.LIGHT_LABELS[lightBand];
+    }
+
+    // Extract the normal perception values from the source
+    let active = spotPair?.normal ?? spotPair;
+    let value;
+    if (active !== undefined) {
+      value = active;
+      debugData.active = value;
+    }
+    else {
+      value = source.system.skills.prc.passive;
+      debugData.passive = value;
+    }
+
+    // dark = fail, dim = disadvantage, bright = normal
+    if (lightBand <= 0) {
+      perception = -100;
+      debugData.cantSee = perception;
+    }
+    else if (lightBand === 1) {
+      let passiveDisadv = Stealthy5e.GetPassivePerceptionWithDisadvantage(source);
+      if (active !== undefined) {
+        value = spotPair?.disadvantaged ?? value - 5;
+        debugData.activeDisadv = value;
+      }
+      else {
+        value = passiveDisadv;
+        debugData.passiveDisadv = value;
+      }
+      perception = Math.max(value, passiveDisadv);
+      debugData.seesDim = perception;
+    }
+    else {
+      perception = Math.max(value, source.system.skills.prc.passive);
+      debugData.seesBright = perception;
+    }
+
+    // Stealthy.log('adjustForLightingConditions5e', debugData);
+    return perception;
+  }
+
+}

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -249,6 +249,5 @@ export class Stealthy5e extends StealthyBaseEngine {
 }
 
 Hooks.once('init', () => {
-  console.log('========> dnd5e init');
-  Stealthy.engines['dnd5e'] = () => new Stealthy5e();
+  Stealthy.RegisterEngine('dnd5e', () => new Stealthy5e());
 });

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -120,7 +120,7 @@ export class Stealthy5e extends StealthyBaseEngine {
     }
 
     const label = game.i18n.localize("stealthy-spot-label");
-    await this.UpdateOrCreateEffect({
+    await this.updateOrCreateEffect({
       label,
       actor,
       flag: { spot: perception },
@@ -140,7 +140,7 @@ export class Stealthy5e extends StealthyBaseEngine {
     Stealthy.log('Stealthy5e.rollStealth', { actor, roll });
 
     const label = game.i18n.localize("stealthy-hidden-label");
-    await this.UpdateOrCreateEffect({
+    await this.updateOrCreateEffect({
       label,
       actor,
       flag: { hidden: roll.total },

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -124,15 +124,7 @@ export class Stealthy5e extends StealthyBaseEngine {
       label,
       actor,
       flag: { spot: perception },
-      makeEffect: (flag, source) => ({
-        label,
-        icon: 'icons/commodities/biological/eye-blue.webp',
-        duration: { turns: 1, seconds: 6 },
-        flags: {
-          convenientDescription: game.i18n.localize("stealthy-spot-description"),
-          stealthy: flag
-        },
-      })
+      makeEffect: this.makeSpotEffect(label)
     });
   }
 
@@ -144,35 +136,7 @@ export class Stealthy5e extends StealthyBaseEngine {
       label,
       actor,
       flag: { hidden: roll.total },
-      makeEffect: (flag, source) => {
-        let hidden = {
-          label,
-          icon: 'icons/magic/perception/shadow-stealth-eyes-purple.webp',
-          changes: [],
-          flags: {
-            convenientDescription: game.i18n.localize("stealthy-hidden-description"),
-            stealthy: flag,
-            core: { statusId: '1' },
-          },
-        };
-        if (source === 'ae') {
-          if (typeof TokenMagic !== 'undefined') {
-            hidden.changes.push({
-              key: 'macro.tokenMagic',
-              mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
-              value: 'fog'
-            });
-          }
-          else if (typeof ATLUpdate !== 'undefined') {
-            hidden.changes.push({
-              key: 'ATL.alpha',
-              mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
-              value: '0.5'
-            });
-          }
-        }
-        return hidden;
-      }
+      makeEffect: this.makeHiddenEffect(label)
     });
   }
 
@@ -242,7 +206,7 @@ export class Stealthy5e extends StealthyBaseEngine {
       debugData.seesBright = perception;
     }
 
-    // Stealthy.log('adjustForLightingConditions5e', debugData);
+    Stealthy.log('adjustForLightingConditions5e', debugData);
     return perception;
   }
 

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -41,8 +41,7 @@ export class Stealthy5e extends StealthyBaseEngine {
     return false;
   }
 
-  basicVision(wrapped, visionSource, mode, config)
-  {
+  basicVision(wrapped, visionSource, mode, config) {
     const target = config.object?.actor;
     let noDarkvision = false;
     const ignoreFriendlyUmbralSight =
@@ -64,7 +63,7 @@ export class Stealthy5e extends StealthyBaseEngine {
   }
 
   static async rollPerception(actor, roll) {
-    if (!Stealthy.enableSpot) return;
+    if (!game.stealthy.activeSpot) return;
     Stealthy.log('rollPerception', { actor, roll });
 
     let perception = { normal: roll.total, disadvantaged: roll.total };
@@ -77,7 +76,7 @@ export class Stealthy5e extends StealthyBaseEngine {
         }
       }
       else {
-        let disadvantageRoll = await new Roll(`1d20`).evaluate();
+        let disadvantageRoll = await new Roll(`1d20`).evaluate({ async: true });
         game.dice3d?.showForRoll(disadvantageRoll);
         const delta = dice.results[0].result - disadvantageRoll.total;
         if (delta > 0) {
@@ -145,7 +144,7 @@ export class Stealthy5e extends StealthyBaseEngine {
 
   getHiddenFlagAndValue(hidden) {
     const value = hidden.flags.stealthy?.hidden ?? actor.system.skills.ste.passive;
-    return { flag: {hidden: value}, value };
+    return { flag: { hidden: value }, value };
   }
 
   async setHiddenValue(actor, effect, flag, value) {
@@ -165,7 +164,7 @@ export class Stealthy5e extends StealthyBaseEngine {
       flag.normal = actor.system.skills.prc.passive;
       disadvantaged = Stealthy5e.GetPassivePerceptionWithDisadvantage(actor);
     }
-    return { flag: {spot: flag}, value: flag.normal };
+    return { flag: { spot: flag }, value: flag.normal };
   }
 
   async setSpotValue(actor, effect, flag, value) {
@@ -181,7 +180,7 @@ export class Stealthy5e extends StealthyBaseEngine {
     // todo: don't apply -5 if already disadvantaged
     return source.system.skills.prc.passive - 5;
   }
-  
+
   static AdjustForDefaultConditions(spotPair, visionSource, source, target) {
     let perception = spotPair?.normal
       ?? spotPair
@@ -248,3 +247,8 @@ export class Stealthy5e extends StealthyBaseEngine {
   }
 
 }
+
+Hooks.once('init', () => {
+  console.log('========> dnd5e init');
+  Stealthy.engines['dnd5e'] = () => new Stealthy5e();
+});

--- a/scripts/systems/pf1.js
+++ b/scripts/systems/pf1.js
@@ -70,6 +70,5 @@ export class StealthyPF1 extends StealthyBaseEngine {
 }
 
 Hooks.once('init', () => {
-  console.log('========> pf1 init');
-  Stealthy.engines['pf1'] = () => new StealthyPF1();
+  Stealthy.RegisterEngine('pf1', () => new StealthyPF1());
 });

--- a/scripts/systems/pf1.js
+++ b/scripts/systems/pf1.js
@@ -62,15 +62,7 @@ export class StealthyPF1 extends StealthyBaseEngine {
       label,
       actor,
       flag: { spot: message.rolls[0].total },
-      makeEffect: (flag, source) => ({
-        label,
-        icon: 'icons/commodities/biological/eye-blue.webp',
-        duration: { turns: 1, seconds: 6 },
-        flags: {
-          convenientDescription: game.i18n.localize("stealthy-spot-description"),
-          stealthy: flag
-        },
-      })
+      makeEffect: this.makeSpotEffect(label)
     });
   }
 
@@ -82,35 +74,7 @@ export class StealthyPF1 extends StealthyBaseEngine {
       label,
       actor,
       flag: { hidden: message.rolls[0].total },
-      makeEffect: (flag, source) => {
-        let hidden = {
-          label,
-          icon: 'icons/magic/perception/shadow-stealth-eyes-purple.webp',
-          changes: [],
-          flags: {
-            convenientDescription: game.i18n.localize("stealthy-hidden-description"),
-            stealthy: flag,
-            core: { statusId: '1' },
-          },
-        };
-        if (source === 'ae') {
-          if (typeof TokenMagic !== 'undefined') {
-            hidden.changes.push({
-              key: 'macro.tokenMagic',
-              mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
-              value: 'fog'
-            });
-          }
-          else if (typeof ATLUpdate !== 'undefined') {
-            hidden.changes.push({
-              key: 'ATL.alpha',
-              mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
-              value: '0.5'
-            });
-          }
-        }
-        return hidden;
-      }
+      makeEffect: this.makeHiddenEffect(label)
     });
   }
 }

--- a/scripts/systems/pf1.js
+++ b/scripts/systems/pf1.js
@@ -9,22 +9,6 @@ export class StealthyPF1 extends StealthyBaseEngine {
     console.warn(`Stealthy for '${game.system.id}' is stubbed out, needs development`);
   }
 
-  testStealth(visionSource, config) {
-    const target = config.object?.actor;
-    const ignoreFriendlyStealth =
-      game.settings.get('stealthy', 'ignoreFriendlyStealth') &&
-      config.object.document?.disposition === visionSource.object.document?.disposition;
-
-    if (!ignoreFriendlyStealth) {
-      const hidden = target?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden-label") && !e.disabled);
-      if (hidden) {
-        if (this.isHidden(visionSource, hidden, target, config)) return false;
-      }
-    }
-
-    return true;
-  }
-
   isHidden(visionSource, hidden, target, config) {
     // Implement your system's method for testing spot data vs hidden data
     // This should would in the absence of a spot effect on the viewer, using

--- a/scripts/systems/pf1.js
+++ b/scripts/systems/pf1.js
@@ -1,55 +1,117 @@
 import { Stealthy, StealthyBaseEngine } from '../stealthy.js';
 
+// This mechanically works, but I don't know how one is supposed to get rid
+// of the Hidden effect once it is placed given the PF1 UI doesn't seem to show
+// active effects.
+
 export class StealthyPF1 extends StealthyBaseEngine {
 
   constructor() {
-    // Hook the relevant skills to capture spot and hidden test
-    // results into effects on the actor.
     super();
-    console.warn(`Stealthy for '${game.system.id}' is stubbed out, needs development`);
+
+    Hooks.on('pf1ActorRollSkill', async (actor, message, skill) => {
+      if (skill === 'ste') {
+        await this.rollStealth(actor, message);
+      }
+      else if (skill === 'per') {
+        await this.rollPerception(actor, message);
+      }
+    });
   }
 
   isHidden(visionSource, hidden, target, config) {
-    // Implement your system's method for testing spot data vs hidden data
-    // This should would in the absence of a spot effect on the viewer, using
-    // a passive or default value as necessary
+    const source = visionSource.object?.actor;
+    const stealth = hidden.flags.stealthy?.hidden ?? (10 + target.system.skills.ste.mod);
+    const spot = source?.effects.find(e => e.label === game.i18n.localize("stealthy-spot-label") && !e.disabled);
+    const perception = spot?.flags.stealthy?.spot ?? (10 + target.system.skills.per.mod);
+
+    if (perception <= stealth) {
+      Stealthy.log(`${visionSource.object.name}'s ${perception} can't see ${config.object.name}'s ${stealth}`);
+      return true;
+    }
     return false;
   }
 
-  basicVision(wrapped, visionSource, mode, config) {
-    // Any special filtering beyond stealth testing is handled here, like being invisible to darkvision/etc.
-    return wrapped(visionSource, mode, config);
-  }
-
-  seeInvisibility(wrapped, visionSource, mode, config) {
-    // Any special filtering beyond stealth testing is handled here.
-    return wrapped(visionSource, mode, config);
-  }
-
   getHiddenFlagAndValue(hidden) {
-    // Return the data necessary for storing data about hidden, and the
-    // value that should be shown on the token button input
-    return { flag: { hidden: undefined }, value: undefined };
+    const value = hidden.flags.stealthy?.hidden ?? actor.system.skills.ste.value;
+    return { flag: { hidden: value }, value };
   }
 
   async setHiddenValue(actor, effect, flag, value) {
-    // If the hidden value was changed, do what you need to store it
     flag.hidden = value;
     effect.flags.stealthy = flag;
     await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
   }
 
   getSpotFlagAndValue(spot) {
-    // Return the data necessary for storing data about spot, and the
-    // value that should be shown on the token button input
-    return { flag: { spot: undefined }, value: undefined };
+    const value = spot.flags.stealthy?.spot ?? actor.system.attributes.perception.value;
+    return { flag: { spot: value }, value };
   }
 
   async setSpotValue(actor, effect, flag, value) {
-    // If the spot value was changed, do what you need to store it
     flag.spot = value;
     effect.flags.stealthy = flag;
     await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
+  }
+
+  async rollPerception(actor, message) {
+    Stealthy.log('rollPerception', { actor, message });
+
+    const label = game.i18n.localize("stealthy-spot-label");
+    await this.updateOrCreateEffect({
+      label,
+      actor,
+      flag: { spot: message.rolls[0].total },
+      makeEffect: (flag, source) => ({
+        label,
+        icon: 'icons/commodities/biological/eye-blue.webp',
+        duration: { turns: 1, seconds: 6 },
+        flags: {
+          convenientDescription: game.i18n.localize("stealthy-spot-description"),
+          stealthy: flag
+        },
+      })
+    });
+  }
+
+  async rollStealth(actor, message) {
+    Stealthy.log('rollStealth', { actor, message });
+
+    const label = game.i18n.localize("stealthy-hidden-label");
+    await this.updateOrCreateEffect({
+      label,
+      actor,
+      flag: { hidden: message.rolls[0].total },
+      makeEffect: (flag, source) => {
+        let hidden = {
+          label,
+          icon: 'icons/magic/perception/shadow-stealth-eyes-purple.webp',
+          changes: [],
+          flags: {
+            convenientDescription: game.i18n.localize("stealthy-hidden-description"),
+            stealthy: flag,
+            core: { statusId: '1' },
+          },
+        };
+        if (source === 'ae') {
+          if (typeof TokenMagic !== 'undefined') {
+            hidden.changes.push({
+              key: 'macro.tokenMagic',
+              mode: CONST.ACTIVE_EFFECT_MODES.CUSTOM,
+              value: 'fog'
+            });
+          }
+          else if (typeof ATLUpdate !== 'undefined') {
+            hidden.changes.push({
+              key: 'ATL.alpha',
+              mode: CONST.ACTIVE_EFFECT_MODES.OVERRIDE,
+              value: '0.5'
+            });
+          }
+        }
+        return hidden;
+      }
+    });
   }
 }
 

--- a/scripts/systems/pf1.js
+++ b/scripts/systems/pf1.js
@@ -1,8 +1,12 @@
-export class StealthyBaseEngine {
+import { Stealthy, StealthyBaseEngine } from '../stealthy.js';
+
+export class StealthyPF1 extends StealthyBaseEngine {
 
   constructor() {
     // Hook the relevant skills to capture spot and hidden test
     // results into effects on the actor.
+    super();
+    console.warn(`Stealthy for '${game.system.id}' is stubbed out, needs development`);
   }
 
   testStealth(visionSource, config) {
@@ -63,83 +67,4 @@ export class StealthyBaseEngine {
     effect.flags.stealthy = flag;
     await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
   }
-}
-
-export class Stealthy {
-
-  static CONSOLE_COLORS = ['background: #222; color: #80ffff', 'color: #fff'];
-  static socket;
-  static enableSpot = true;
-  static engine;
-
-  static log(format, ...args) {
-    const level = game.settings.get('stealthy', 'logLevel');
-    if (level !== 'none') {
-
-      function colorizeOutput(format, ...args) {
-        return [
-          `%cstealthy %c|`,
-          ...Stealthy.CONSOLE_COLORS,
-          format,
-          ...args,
-        ];
-      }
-
-      if (level === 'debug')
-        console.debug(...colorizeOutput(format, ...args));
-      else if (level === 'log')
-        console.log(...colorizeOutput(format, ...args));
-    }
-  }
-
-  //########### Socket Functions ##############
-
-  static async toggleSpotting(toggled) {
-    Stealthy.enableSpot = toggled;
-
-    if (!toggled && game.user.isGM) {
-      const label = game.i18n.localize('stealthy-spot-label');
-      for (let token of canvas.tokens.placeables) {
-        const actor = token.actor;
-        const spot = actor.effects.find(e => e.label === label);
-        if (spot) {
-          actor.deleteEmbeddedDocuments('ActiveEffect', [spot.id]);
-        }
-      }
-    }
-  }
-
-  static async getSpotting() {
-    return Stealthy.enableSpot;
-  }
-
-  static async UpdateOrCreateEffect({ label, actor, flag, makeEffect }) {
-    let effect = actor.effects.find(e => e.label === label);
-
-    if (!effect) {
-      // See if we can source from outside
-      const source = game.settings.get('stealthy', 'hiddenSource');
-      if (source === 'ce') {
-        await game.dfreds.effectInterface.addEffect({ effectName: label, uuid: actor.uuid });
-        effect = actor.effects.find(e => e.label === label);
-      }
-      else if (source === 'cub') {
-        await game.cub.applyCondition(label, actor);
-        effect = actor.effects.find(e => e.label === label);
-      }
-
-      // If we haven't found an ouside source, create the default one
-      if (!effect) {
-        effect = makeEffect(flag, source);
-        await actor.createEmbeddedDocuments('ActiveEffect', [effect]);
-        return;
-      }
-    }
-
-    effect = duplicate(effect);
-    effect.flags.stealthy = flag;
-    effect.disabled = false;
-    await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
-  }
-
 }

--- a/scripts/systems/pf1.js
+++ b/scripts/systems/pf1.js
@@ -68,3 +68,8 @@ export class StealthyPF1 extends StealthyBaseEngine {
     await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
   }
 }
+
+Hooks.once('init', () => {
+  console.log('========> pf1 init');
+  Stealthy.engines['pf1'] = () => new StealthyPF1();
+});

--- a/scripts/systems/pf2e.js
+++ b/scripts/systems/pf2e.js
@@ -70,6 +70,5 @@ export class StealthyPF2e extends StealthyBaseEngine {
 }
 
 Hooks.once('init', () => {
-  console.log('========> pf2e init');
-  Stealthy.engines['pf2e'] = () => new StealthyPF2e();
+  Stealthy.RegisterEngine('pf2e', () => new StealthyPF2e());
 });

--- a/scripts/systems/pf2e.js
+++ b/scripts/systems/pf2e.js
@@ -1,8 +1,12 @@
-export class StealthyBaseEngine {
+import { Stealthy, StealthyBaseEngine } from '../stealthy.js';
+
+export class StealthyPF2e extends StealthyBaseEngine {
 
   constructor() {
     // Hook the relevant skills to capture spot and hidden test
     // results into effects on the actor.
+    super();
+    console.warn(`Stealthy for '${game.system.id}' is stubbed out, needs development`);
   }
 
   testStealth(visionSource, config) {
@@ -63,83 +67,4 @@ export class StealthyBaseEngine {
     effect.flags.stealthy = flag;
     await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
   }
-}
-
-export class Stealthy {
-
-  static CONSOLE_COLORS = ['background: #222; color: #80ffff', 'color: #fff'];
-  static socket;
-  static enableSpot = true;
-  static engine;
-
-  static log(format, ...args) {
-    const level = game.settings.get('stealthy', 'logLevel');
-    if (level !== 'none') {
-
-      function colorizeOutput(format, ...args) {
-        return [
-          `%cstealthy %c|`,
-          ...Stealthy.CONSOLE_COLORS,
-          format,
-          ...args,
-        ];
-      }
-
-      if (level === 'debug')
-        console.debug(...colorizeOutput(format, ...args));
-      else if (level === 'log')
-        console.log(...colorizeOutput(format, ...args));
-    }
-  }
-
-  //########### Socket Functions ##############
-
-  static async toggleSpotting(toggled) {
-    Stealthy.enableSpot = toggled;
-
-    if (!toggled && game.user.isGM) {
-      const label = game.i18n.localize('stealthy-spot-label');
-      for (let token of canvas.tokens.placeables) {
-        const actor = token.actor;
-        const spot = actor.effects.find(e => e.label === label);
-        if (spot) {
-          actor.deleteEmbeddedDocuments('ActiveEffect', [spot.id]);
-        }
-      }
-    }
-  }
-
-  static async getSpotting() {
-    return Stealthy.enableSpot;
-  }
-
-  static async UpdateOrCreateEffect({ label, actor, flag, makeEffect }) {
-    let effect = actor.effects.find(e => e.label === label);
-
-    if (!effect) {
-      // See if we can source from outside
-      const source = game.settings.get('stealthy', 'hiddenSource');
-      if (source === 'ce') {
-        await game.dfreds.effectInterface.addEffect({ effectName: label, uuid: actor.uuid });
-        effect = actor.effects.find(e => e.label === label);
-      }
-      else if (source === 'cub') {
-        await game.cub.applyCondition(label, actor);
-        effect = actor.effects.find(e => e.label === label);
-      }
-
-      // If we haven't found an ouside source, create the default one
-      if (!effect) {
-        effect = makeEffect(flag, source);
-        await actor.createEmbeddedDocuments('ActiveEffect', [effect]);
-        return;
-      }
-    }
-
-    effect = duplicate(effect);
-    effect.flags.stealthy = flag;
-    effect.disabled = false;
-    await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
-  }
-
 }

--- a/scripts/systems/pf2e.js
+++ b/scripts/systems/pf2e.js
@@ -68,3 +68,8 @@ export class StealthyPF2e extends StealthyBaseEngine {
     await actor.updateEmbeddedDocuments('ActiveEffect', [effect]);
   }
 }
+
+Hooks.once('init', () => {
+  console.log('========> pf2e init');
+  Stealthy.engines['pf2e'] = () => new StealthyPF2e();
+});

--- a/scripts/systems/pf2e.js
+++ b/scripts/systems/pf2e.js
@@ -9,22 +9,6 @@ export class StealthyPF2e extends StealthyBaseEngine {
     console.warn(`Stealthy for '${game.system.id}' is stubbed out, needs development`);
   }
 
-  testStealth(visionSource, config) {
-    const target = config.object?.actor;
-    const ignoreFriendlyStealth =
-      game.settings.get('stealthy', 'ignoreFriendlyStealth') &&
-      config.object.document?.disposition === visionSource.object.document?.disposition;
-
-    if (!ignoreFriendlyStealth) {
-      const hidden = target?.effects.find(e => e.label === game.i18n.localize("stealthy-hidden-label") && !e.disabled);
-      if (hidden) {
-        if (this.isHidden(visionSource, hidden, target, config)) return false;
-      }
-    }
-
-    return true;
-  }
-
   isHidden(visionSource, hidden, target, config) {
     // Implement your system's method for testing spot data vs hidden data
     // This should would in the absence of a spot effect on the viewer, using
@@ -32,14 +16,16 @@ export class StealthyPF2e extends StealthyBaseEngine {
     return false;
   }
 
-  basicVision(wrapped, visionSource, mode, config) {
-    // Any special filtering beyond stealth testing is handled here, like being invisible to darkvision/etc.
-    return wrapped(visionSource, mode, config);
+  makeHiddenEffect(label) {
+    console.error(`'${game.system.id}' can't make a Hidden effect. Heavy lifting goes here.`);
   }
 
-  seeInvisibility(wrapped, visionSource, mode, config) {
-    // Any special filtering beyond stealth testing is handled here.
-    return wrapped(visionSource, mode, config);
+  makeSpotEffect(label) {
+    console.error(`'${game.system.id}' isn't make a Spot effect. Heavy lifting goes here.`);
+  }
+
+  async updateOrCreateEffect({ label, actor, flag, makeEffect }) {
+    console.error(`'${game.system.id}' isn't compatible with Active Effect use. Heavy lifting goes here.`);
   }
 
   getHiddenFlagAndValue(hidden) {


### PR DESCRIPTION
* PF1 support - effect cleanup is macro based so buyer beware
* PF2e support parked due to active effect incompatibility
* Experimental: Converted Perception roll results into roll pairs for Spot, rolling an extra die if needed
* Experimental: Dim and Hidden conditions on viewed token applies disadvantage to Perception during visibility test