### PR TITLE
Add setting for Foundry vs 5E behavior in dim light with darkvision

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# pending
+* Add choice to match Foundry lighting or 5E rules for perception tests in dim lighting
+* Added settings for changin localization keys for dim/dark
+
 # v2.3.0
 * Spot and Hidden effects can have different sources.
 * Spot and Hidden effect label can be customized.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # pending
 * Add choice to match Foundry lighting or 5E rules for perception tests in dim lighting
-* Added settings for changin localization keys for dim/dark
+* Added settings for changing localization keys for dim/dark
 
 # v2.3.0
 * Spot and Hidden effects can have different sources.

--- a/README.md
+++ b/README.md
@@ -59,14 +59,9 @@ D&D 5E treats skill contest ties as preserving the status quo, so use of passive
 
 ### Experimental - Lighting effects on Perception vs Hidden token
 For this approach we are only looking at dnd5e and we've broken this down into three pieces:
-- Detecting the light level on the token itself, which is independant of viewer. Stealthy looks for 'Dim' or 'Dark' status effects on the token and does no light calculations itself; [Token Light Condition](https://foundryvtt.com/packages/tokenlightcondition) was written as a separate module to handle this.
-- Remapping the dim/dark light level per viewer based on their viewing mode. At least 3 different mapping tables are needed:
-  - Foundry Darkvision: Dark -> Dim; Dim -> Bright **(Current Implementation)**
-  - RAW 5E Darkvision: Dark -> Dim
-  - Demonsight: Dark -> Bright
-
-  After the light level is remapped, objects in 'Dark' get rejected and objects in 'Dim' would be tested against using disadvantaged perception.
-- Capturing the advantage/disadvantage state of the viewers perception in order to do the right thing when applying disadvantage in dim vision. We get these flags on the active rolls, and can generate an extra roll result we can store in our flag so that we have a result for disadvantage should we need it. **We don't have a cost-effective way to figure out pre-existing passive disadvantage on perception, so this edge case will cause those tokens to end up taking the -5 penalty twice. You have been warned.**
+- Detecting the light level on the token itself, which is independant of viewer. Stealthy looks for 'Dim' or 'Dark' status effects on the token and does no light calculations itself - see [Token Light Condition](https://foundryvtt.com/packages/tokenlightcondition) for this work.
+- Remapping the dim/dark light level per viewer based on their viewing mode. After the light level is remapped, objects in 'Dark' get rejected and objects in 'Dim' would be tested against using disadvantaged perception.
+- Capturing the advantage/disadvantage state of the viewers perception in order to do the right thing when applying disadvantage in dim vision. We get these flags on the active rolls, and can generate an extra roll result we can store in our flag so that we have a result for disadvantage should we need it. **We haven't yet figured out how to handle pre-existing passive disadvantage on perception inside the visibility test itself, so this edge case will cause those tokens to end up taking the -5 penalty twice. You have been warned.**
 
 ## pf1
   - I assume take-10 perception for tokens without an active spot effect. It isn't RAW, but perhaps this is acceptable to the PF1 community.

--- a/languages/en.json
+++ b/languages/en.json
@@ -58,13 +58,23 @@
       "config.experimental": "Experimental",
       "tokenLighting": {
         "name": "Check token lighting conditions",
-        "hint": "Check for token effects that indicate lighting condition of the token. WARNING - only currently handles passive perception"
+        "hint": "Check for token effects that indicate lighting condition of the token."
       },
-      "dark.label": "Dark",
-      "dim.label": "Dim",
+      "dark": {
+        "label": "Dark",
+        "key": "Localization key for Dark label"
+      },
+      "dim": {
+        "label": "Dim",
+        "key": "Localization key for Dim label"
+      },
       "spotPair": {
         "name": "Record disadvantaged Perception when rolling a check",
         "hint": "Parse Perception roll results to have both a normal and disadvantaged result, rolling a second die if necessary"
+      },
+      "dimIsBright": {
+        "name": "Treat Dim as Bright in Darkvision",
+        "hint": "Enabling this matches Foundry Darkvision behavior, disabling this matches 5E rules. Install the 'Adequate Vision' module if you wish Foundry visuals to more closely match 5E rules."
       }
     }
   }

--- a/languages/pt-BR.json
+++ b/languages/pt-BR.json
@@ -58,13 +58,23 @@
       "config.experimental": "Experimental",
       "tokenLighting": {
         "name": "Verificar as condições de iluminação dos tokens",
-        "hint": "Verificar se há efeitos de token que indicam a condição de iluminação dos tokens. AVISO - atualmente lida apenas com Percepção passiva"
+        "hint": "Verificar se há efeitos de token que indicam a condição de iluminação dos tokens."
       },
-      "dark.label": "Escuro",
-      "dim.label": "Penumbra",
+      "dark": {
+        "label": "Escuro",
+        "key": "Chave de localização para rótulo Escuro"
+      },
+      "dim": {
+        "label": "Penumbra",
+        "key": "Chave de localização para rótulo Penumbra"
+      },
       "spotPair": {
         "name": "Registar Percepção com desvantagem ao rolar um teste",
         "hint": "Analisar os resultados do teste de Percepção para obter um resultado normal e um com desvantagem, rolando um segundo dado se necessário"
+      },
+      "dimIsBright": {
+        "name": "Trate Penumbra como Escuro em Visão Escura",
+        "hint": "Habilitar isso corresponde ao comportamento do Foundry, desabilitar isso corresponde às regras 5E. Instale o módulo 'Adequate Vision' se desejar que os visuais do Foundry correspondam mais às regras 5E."
       }
     }
   }

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -23,6 +23,37 @@ export class Stealthy5e extends StealthyBaseEngine {
       default: false,
     });
 
+    game.settings.register(Stealthy.MODULE_ID, 'darkLabel', {
+      name: game.i18n.localize("stealthy.hidden.dark.key"),
+      scope: 'world',
+      config: true,
+      type: String,
+      default: 'stealthy.dnd5e.dark.label',
+      onChange: value => {
+        debouncedReload();
+      }
+    });
+
+    game.settings.register(Stealthy.MODULE_ID, 'dimLabel', {
+      name: game.i18n.localize("stealthy.dnd5e.dim.key"),
+      scope: 'world',
+      config: true,
+      type: String,
+      default: 'stealthy.dnd5e.dim.label',
+      onChange: value => {
+        debouncedReload();
+      }
+    });
+
+    game.settings.register(Stealthy.MODULE_ID, 'dimIsBright', {
+      name: game.i18n.localize("stealthy.dnd5e.dimIsBright.name"),
+      hint: game.i18n.localize("stealthy.dnd5e.dimIsBright.hint"),
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: false,
+    });
+
     Hooks.on('dnd5e.rollSkill', async (actor, roll, skill) => {
       if (skill === 'ste') {
         await this.rollStealth(actor, roll);
@@ -31,6 +62,9 @@ export class Stealthy5e extends StealthyBaseEngine {
         await this.rollPerception(actor, roll);
       }
     });
+
+    this.dimLabel = game.i18n.localize(game.settings.get(Stealthy.MODULE_ID, 'dimLabel'));
+    this.darkLabel = game.i18n.localize(game.settings.get(Stealthy.MODULE_ID, 'darkLabel'));
   }
 
   static LIGHT_LABELS = ['dark', 'dim', 'bright'];
@@ -170,19 +204,14 @@ export class Stealthy5e extends StealthyBaseEngine {
 
     // What light band are we told we sit in?
     let lightBand = 2;
-    if (target?.effects.find(e => e.label === game.i18n.localize("stealthy.dnd5e.dark.label") && !e.disabled)) { lightBand = 0; }
-    if (target?.effects.find(e => e.label === game.i18n.localize("stealthy.dnd5e.dim.label") && !e.disabled)) { lightBand = 1; }
+    if (target?.effects.find(e => e.label === this.darkLabel && !e.disabled)) { lightBand = 0; }
+    if (target?.effects.find(e => e.label === this.dimLabel && !e.disabled)) { lightBand = 1; }
     debugData.lightLevel = Stealthy5e.LIGHT_LABELS[lightBand];
 
     // Adjust the light band based on conditions
     if (visionSource.visionMode?.id === 'darkvision') {
-      const adequate = game.modules.get('adequate-vision');
-      if (adequate) {
-        if (!lightBand) lightBand = 1;
-      }
-      else {
-        lightBand = lightBand + 1;
-      }
+      if (game.settings.get(Stealthy.MODULE_ID, 'tokenLighting')) lightBand = lightBand + 1;
+      else if (!lightBand) lightBand = 1;
       debugData.foundryDarkvision = Stealthy5e.LIGHT_LABELS[lightBand];
     }
 

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -176,7 +176,13 @@ export class Stealthy5e extends StealthyBaseEngine {
 
     // Adjust the light band based on conditions
     if (visionSource.visionMode?.id === 'darkvision') {
-      lightBand = lightBand + 1;
+      const adequate = game.modules.get('adequate-vision');
+      if (adequate) {
+        if (!lightBand) lightBand = 1;
+      }
+      else {
+        lightBand = lightBand + 1;
+      }
       debugData.foundryDarkvision = Stealthy5e.LIGHT_LABELS[lightBand];
     }
 


### PR DESCRIPTION
* Add choice to match Foundry lighting or 5E rules for perception tests in dim lighting
* Added settings for changing localization keys for dim/dark
