### PR TITLE
DCs on Secret Doors

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,5 @@
 # Pending
-* Add Perception DC to secret doors
+* GMs can enable Players to automatically spot secret doors by beating the door's DC with perception.
 
 # v2.4.0
 * Add choice to match Foundry lighting or 5E rules for perception tests in dim lighting

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# Pending
+* Add Perception DC to secret doors
+
 # v2.4.0
 * Add choice to match Foundry lighting or 5E rules for perception tests in dim lighting
 * Added settings for changing localization keys for dim/dark

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ An invisible actor that also has the 'Hidden' effect will check Perception vs St
 
 ![invisible](https://user-images.githubusercontent.com/16523503/210176827-03fda57a-6d09-4144-8253-b8b7cd9155ac.gif)
 
+## **Secret doors can be seen based on Spot roll**
+If enabled, secret doors can now specify a perception DC, allowing them to be seen only by viewing actors with a sufficiently high perception result. The behavior of secret doors with a required perception value is unchanged.
+
+![secret-doors](https://user-images.githubusercontent.com/16523503/212574216-6cc5b0ad-f432-441e-b11a-f4aa2b15cbd1.gif)
+
 ## **Friendly tokens can still be viewed**
 The GM has the option for allowing Hidden tokens to be seen by other tokens of the same disposition.
 

--- a/languages/en.json
+++ b/languages/en.json
@@ -51,11 +51,11 @@
       "advanced": "Advanced Options"
     },
     "dnd5e": {
+      "name": "Dnd5e",
       "ignoreFriendlyUmbralSight": {
         "name": "Ignore friendly Umbral Sight",
         "hint": "In darkvision mode, ignore the Umbral Sight feature for tokens of the same disposition"
       },
-      "config.experimental": "Experimental",
       "tokenLighting": {
         "name": "Check token lighting conditions",
         "hint": "Check for token effects that indicate lighting condition of the token."
@@ -78,7 +78,7 @@
       }
     },
     "pf1": {
-      "config": "Pathfinder",
+      "name": "Pathfinder",
       "spotTake10": {
         "name": "Perception take-10",
         "hint": "If no Spot effect is active, assume the Perception take-10 result for the visibility test. If disabled, Hidden tokens will not be seen without an active Spot effect."

--- a/languages/en.json
+++ b/languages/en.json
@@ -20,6 +20,10 @@
       }
     },
     "activeSpot": "Active Spot",
+    "spotSecretDoors": {
+      "name": "Automatic secret door detection",
+      "hint": "Actors can spot hidden doors if their perception check beats the secret door"
+    },
     "ignoreFriendlyStealth": {
       "name": "Ignore friendly stealth",
       "hint": "Perception vs Stealth tests will be ignored for tokens of the same disposition"

--- a/languages/en.json
+++ b/languages/en.json
@@ -54,6 +54,9 @@
       "debug": "Debug Options",
       "advanced": "Advanced Options"
     },
+    "door": {
+      "dc": "Required Perception"
+    },
     "dnd5e": {
       "name": "Dnd5e",
       "ignoreFriendlyUmbralSight": {

--- a/languages/pt-BR.json
+++ b/languages/pt-BR.json
@@ -54,6 +54,9 @@
       "debug": "Opções de depuração",
       "advanced": "Opções avançadas"
     },
+    "door": {
+      "dc": "Percepção Necessária"
+    },
     "dnd5e": {
       "name": "Dnd5e",
       "ignoreFriendlyUmbralSight": {

--- a/languages/pt-BR.json
+++ b/languages/pt-BR.json
@@ -51,11 +51,11 @@
       "advanced": "Opções avançadas"
     },
     "dnd5e": {
+      "name": "Dnd5e",
       "ignoreFriendlyUmbralSight": {
         "name": "Ignorar Visão Umbral aliada",
         "hint": "No modo de visão no escuro, ignorar a habilidade Visão Umbral para tokens com a mesma disposição"
       },
-      "config.experimental": "Experimental",
       "tokenLighting": {
         "name": "Verificar as condições de iluminação dos tokens",
         "hint": "Verificar se há efeitos de token que indicam a condição de iluminação dos tokens."
@@ -78,7 +78,7 @@
       }
     },
     "pf1": {
-      "config": "Pathfinder",
+      "name": "Pathfinder",
       "spotTake10": {
         "name": "Percepção pegue-10",
         "hint": "Se nenhum efeito Percebido estiver ativo, assuma o resultado de Percepção - 10 para o teste de visibilidade. Se desativado, os tokens Escondido não serão vistos sem um efeito Percebido ativo."

--- a/languages/pt-BR.json
+++ b/languages/pt-BR.json
@@ -20,6 +20,10 @@
       }
     },
     "activeSpot": "Ativamente percebido",
+    "spotSecretDoors": {
+      "name": "Detecção automática de porta secreta",
+      "hint": "Os atores podem localizar portas ocultas se seu teste de percepção vencer a porta secreta"
+    },
     "ignoreFriendlyStealth": {
       "name": "Ignorar Furtividade aliada",
       "hint": "Testes de Percepção vs Furtividade serão ignorados para tokens com a mesma disposição"

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -13,17 +13,6 @@ Hooks.once('setup', () => {
     default: true,
   });
 
-  if (game.system.id === 'dnd5e') {
-    game.settings.register(Stealthy.MODULE_ID, 'ignoreFriendlyUmbralSight', {
-      name: game.i18n.localize("stealthy.dnd5e.ignoreFriendlyUmbralSight.name"),
-      hint: game.i18n.localize("stealthy.dnd5e.ignoreFriendlyUmbralSight.hint"),
-      scope: 'world',
-      config: true,
-      type: Boolean,
-      default: false,
-    });
-  }
-
   let sources = {
     'none': game.i18n.localize("stealthy.source.min"),
     'ae': game.i18n.localize("stealthy.source.ae"),

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -20,6 +20,9 @@ Hooks.once('setup', () => {
     config: true,
     type: Boolean,
     default: false,
+    onChange: value => {
+      debouncedReload();
+    },
   });
 
   let sources = {

--- a/scripts/hooks.js
+++ b/scripts/hooks.js
@@ -13,6 +13,15 @@ Hooks.once('setup', () => {
     default: true,
   });
 
+  game.settings.register(Stealthy.MODULE_ID, 'spotSecretDoors', {
+    name: game.i18n.localize("stealthy.spotSecretDoors.name"),
+    hint: game.i18n.localize("stealthy.spotSecretDoors.hint"),
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+
   let sources = {
     'none': game.i18n.localize("stealthy.source.min"),
     'ae': game.i18n.localize("stealthy.source.ae"),

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -5,6 +5,15 @@ export class Stealthy5e extends StealthyBaseEngine {
   constructor() {
     super();
 
+    game.settings.register(Stealthy.MODULE_ID, 'ignoreFriendlyUmbralSight', {
+      name: game.i18n.localize("stealthy.dnd5e.ignoreFriendlyUmbralSight.name"),
+      hint: game.i18n.localize("stealthy.dnd5e.ignoreFriendlyUmbralSight.hint"),
+      scope: 'world',
+      config: true,
+      type: Boolean,
+      default: false,
+    });
+
     game.settings.register(Stealthy.MODULE_ID, 'tokenLighting', {
       name: game.i18n.localize("stealthy.dnd5e.tokenLighting.name"),
       hint: game.i18n.localize("stealthy.dnd5e.tokenLighting.hint"),
@@ -65,6 +74,13 @@ export class Stealthy5e extends StealthyBaseEngine {
 
     this.dimLabel = game.i18n.localize(game.settings.get(Stealthy.MODULE_ID, 'dimLabel'));
     this.darkLabel = game.i18n.localize(game.settings.get(Stealthy.MODULE_ID, 'darkLabel'));
+
+    Hooks.on('renderSettingsConfig', (app, html, data) => {
+      $('<div>').addClass('form-group group-header')
+        .html(game.i18n.localize("stealthy.dnd5e.name"))
+        .insertBefore($('[name="stealthy.ignoreFriendlyUmbralSight"]')
+          .parents('div.form-group:first'));
+    });
   }
 
   static LIGHT_LABELS = ['dark', 'dim', 'bright'];
@@ -130,14 +146,14 @@ export class Stealthy5e extends StealthyBaseEngine {
 
   getSpotFlagAndValue(actor, effect) {
     let flag = { normal: undefined, disadvantaged: undefined };
-    const active = effect.flags.stealthy?.spot?.normal ?? effect.flags.stealthy?.spot;
+    const active = effect?.flags.stealthy?.spot?.normal ?? effect?.flags.stealthy?.spot;
     if (active !== undefined) {
       flag.normal = active;
       flag.disadvantaged = effect.flags.stealthy?.spot?.disadvantaged ?? active - 5;
     }
     else {
       flag.normal = actor.system.skills.prc.passive;
-      disadvantaged = Stealthy5e.GetPassivePerceptionWithDisadvantage(actor);
+      flag.disadvantaged = Stealthy5e.GetPassivePerceptionWithDisadvantage(actor);
     }
     return { flag: { spot: flag }, value: flag.normal };
   }
@@ -258,8 +274,4 @@ export class Stealthy5e extends StealthyBaseEngine {
 
 Hooks.once('init', () => {
   Stealthy.RegisterEngine('dnd5e', () => new Stealthy5e());
-});
-
-Hooks.on('renderSettingsConfig', (app, html, data) => {
-  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy.dnd5e.config.experimental")).insertBefore($('[name="stealthy.tokenLighting"]').parents('div.form-group:first'));
 });

--- a/scripts/systems/pf1.js
+++ b/scripts/systems/pf1.js
@@ -26,6 +26,13 @@ export class StealthyPF1 extends StealthyBaseEngine {
         await this.rollPerception(actor, message);
       }
     });
+
+    Hooks.on('renderSettingsConfig', (app, html, data) => {
+      $('<div>').addClass('form-group group-header')
+        .html(game.i18n.localize("stealthy.pf1.name"))
+        .insertBefore($('[name="stealthy.spotTake10"]')
+          .parents('div.form-group:first'));
+    });
   }
 
   isHidden(visionSource, hiddenEffect, target) {
@@ -68,8 +75,4 @@ export class StealthyPF1 extends StealthyBaseEngine {
 
 Hooks.once('init', () => {
   Stealthy.RegisterEngine('pf1', () => new StealthyPF1());
-});
-
-Hooks.on('renderSettingsConfig', (app, html, data) => {
-  $('<div>').addClass('form-group group-header').html(game.i18n.localize("stealthy.pf1.config")).insertBefore($('[name="stealthy.spotTake10"]').parents('div.form-group:first'));
 });


### PR DESCRIPTION
* GMs can enable Players to automatically spot secret doors by beating the door's DC with perception