### PR TITLE
v3.5.0

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# v3.5.0
+* Only add duration to default Spot effect if combat is active, allowing one to bank spot checks out-of-combat rather than just using the passive Spot value. Spot effects coming from CE or CUB are unaffected, taking whatever duration is specified in the supplied effect.
+
 # v3.4.0
 * If multiple controlled tokens are selected, hidden doors will display if at least one token would be able to perceive the hidden door.
 * If no viewing token is selected, hidden doors will only display on the GM client.

--- a/module.json
+++ b/module.json
@@ -19,14 +19,14 @@
         "id": "dnd4e",
         "type": "system",
         "compatibility": {
-          "verified": "0.3.20"
+          "verified": "0.3.32"
         }
       },
       {
         "id": "dnd5e",
         "type": "system",
         "compatibility": {
-          "verified": "2.1.4"
+          "verified": "2.1.5"
         }
       },
       {

--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -151,7 +151,7 @@ class Engine5e extends Engine {
   makeSpotEffectMaker(label) {
     return (flag, source) => {
       let effect = super.makeSpotEffectMaker(label)(flag, source);
-      effect.duration = { turns: 1, seconds: 6 };
+      if (game.combat) effect.duration = { turns: 1, seconds: 6 };
       return effect;
     };
   }


### PR DESCRIPTION
* Only add duration to default Spot effect if combat is active, allowing one to bank spot checks out-of-combat rather than just using the passive Spot value. Spot effects coming from CE or CUB are unaffected, taking whatever duration is specified in the supplied effect.