### PR TITLE
Don't apply seek status with perception intiative

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# v3.13.2
+* PF2e: Don't apply seek status when rolling intiative based on perception
+
 # v3.13.1
 * PF2e/Dnd4e: Localize the chat scraping functions
 

--- a/scripts/systems/pf2e.js
+++ b/scripts/systems/pf2e.js
@@ -22,7 +22,6 @@ export class EnginePF2e extends Engine {
     ]; 
     const perceptionTags = [
       `>${game.i18n.localize('xdy-pf2e-workbench.macros.basicActionMacros.actions.Seek')} - ${game.i18n.localize('PF2E.PerceptionCheck')}<`,
-      `>${game.i18n.format("PF2E.InitiativeWithSkill", { skillName: game.i18n.localize('PF2E.PerceptionLabel') })}<`,
     ];
     Stealthy.log('Localized Chat Tags', { stealthTags, perceptionTags });
 


### PR DESCRIPTION
* PF2e: Don't apply seek status when rolling intiative based on perception