### PR TITLE
57 dnd5e disadvantaged passive perception

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# v4.0.8
+* look for midi-qol flag to determine if perception disadvantage is already present before adding a -5 penalty to passive perception in dim light
+
 # v4.0.7
 * v12 compatability
 


### PR DESCRIPTION
* look for midi-qol flag to determine if perception disadvantage is already present before adding a -5 penalty to passive perception in dim light