### PR TITLE
Fix pre-v5 compatibility

### DIFF
--- a/scripts/systems/dnd5e.js
+++ b/scripts/systems/dnd5e.js
@@ -86,7 +86,7 @@ class Engine5e extends Engine {
   setup() {
     super.setup();
 
-    const beforeV5 = Math.floor(game.system.version) < 5;
+    const beforeV5 = Number(game.system.version.split(".")[0]) < 5;
     const hiddenSource = game.settings.get(Stealthy.MODULE_ID, "hiddenSource");
 
     const hidingAvailable = CONFIG?.DND5E.statusEffects?.hiding.name;


### PR DESCRIPTION
I just installed stealthy recently and it doesn't seem to work at all. So I dug in and debugged and I think I found the issue.

Firstly, I should say I'm running Foundry v12.331 and dnd5e v3.3.1

Digging in via the debugger, I found this line: `const beforeV5 = Math.floor(game.system.version) < 5;`. Well, `game.system.version` returns `"3.3.1"`. Since that's not a number, `Math.floor(game.system.version)` becomes `NaN` and `beforeV5` becomes `false`

In this PR, I've changed it to what I think is the intended behavior, which is to split off the major version and use that for the comparison. I'm not really sure what the `Math.floor` was for, so I removed it.

Testing it on my environment with this change, I _think_ it's working properly now. But I'm new to stealthy, so I'm not 100% sure.